### PR TITLE
Community AMI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ defaults: &defaults
 
 version: 2.0
 jobs:
-  test aws:
+  test:
     <<: *defaults
     steps:
       - checkout
@@ -43,12 +43,38 @@ jobs:
       - store_test_results:
           path: /tmp/logs
 
+  release:
+    machine: true
+    steps:
+      - checkout
+
+      # The weird way you have to set PATH in Circle 2.0
+      - run: echo 'export PATH=$HOME/.local/bin:$HOME/terraform:$HOME/packer:$PATH' >> $BASH_ENV
+
+      # Use the Gruntwork Installer to install the gruntwork-module-circleci-helpers
+      - run: curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version v0.0.21
+      - run: gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.13.3"
+      - run: gruntwork-install --module-name "build-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.13.3"
+      - run: gruntwork-install --module-name "aws-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "v0.13.3"
+      - run: configure-environment-for-gruntwork-module --circle-ci-2-machine-executor --go-src-path test --use-go-dep --terraform-version NONE --terragrunt-version NONE --glide-version NONE
+
+      - run: ~/project/.circleci/publish-amis.sh "influxdb-ami-ubuntu"
+      - run: ~/project/.circleci/publish-amis.sh "influxdb-ami-amazon-linux"
 
 workflows:
   version: 2
   build-and-test:
     jobs:
-      - test aws:
+      - test:
           filters:
             tags:
               only: /^v.*/
+      - release:
+          requires:
+            - test
+          # Publish new AMIs whenever a new vesion (e.g., v0.3.4) is released
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/.circleci/publish-amis.sh
+++ b/.circleci/publish-amis.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# Build the example AMI, copy it to all AWS regions, and make all AMIs public.
+#
+# This script is meant to be run in a CircleCI job.
+#
+
+set -e
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+readonly PACKER_TEMPLATE_PATH="$SCRIPT_DIR/../examples/influxdb-ami/influxdb.json"
+readonly PACKER_TEMPLATE_DEFAULT_REGION="us-east-1"
+readonly AMI_PROPERTIES_FILE="/tmp/ami.properties"
+readonly AMI_LIST_MARKDOWN_DIR="$SCRIPT_DIR/../_docs"
+readonly GIT_COMMIT_MESSAGE="Add latest AMI IDs."
+readonly GIT_USER_NAME="gruntwork-ci"
+readonly GIT_USER_EMAIL="ci@gruntwork.io"
+
+# In CircleCI, every build populates the branch name in CIRCLE_BRANCH except builds triggered by a new tag, for which
+# the CIRCLE_BRANCH env var is empty. We assume tags are only issued against the master branch.
+readonly BRANCH_NAME="${CIRCLE_BRANCH:-master}"
+
+readonly PACKER_BUILD_NAME="$1"
+
+if [[ -z "$PACKER_BUILD_NAME" ]]; then
+  echo "ERROR: You must pass in the Packer build name as the first argument to this function."
+  exit 1
+fi
+
+if [[ -z "$AMI_PUBLISHING_ACCESS_KEY_ID" || -z "$AMI_PUBLISHING_SECRET_ACCESS_KEY" ]]; then
+  echo "ERROR: This script expects AWS access keys for publishing public AMIs to be set as the environment variables AMI_PUBLISHING_ACCESS_KEY_ID and AMI_PUBLISHING_SECRET_ACCESS_KEY."
+  exit 1
+fi
+
+# Publish AMIs to a different AWS account (not our test account) to ensure they don't get deleted by cloud-nuke
+export AWS_ACCESS_KEY_ID="$AMI_PUBLISHING_ACCESS_KEY_ID"
+export AWS_SECRET_ACCESS_KEY="$AMI_PUBLISHING_SECRET_ACCESS_KEY"
+
+# Build the example AMI. WARNING! In a production setting, you should build your own AMI to ensure it has exactly the
+# configuration you want. We build this example AMI solely to make initial use of this Module as easy as possible.
+build-packer-artifact \
+  --packer-template-path "$PACKER_TEMPLATE_PATH" \
+  --build-name "$PACKER_BUILD_NAME" \
+  --output-properties-file "$AMI_PROPERTIES_FILE"
+
+# Copy the AMI to all regions and make it public in each
+source "$AMI_PROPERTIES_FILE"
+publish-ami \
+  --all-regions \
+  --source-ami-id "$ARTIFACT_ID" \
+  --source-ami-region "$PACKER_TEMPLATE_DEFAULT_REGION" \
+  --output-markdown > "$AMI_LIST_MARKDOWN_DIR/$PACKER_BUILD_NAME-list.md" \
+  --markdown-title-text "$PACKER_BUILD_NAME: Latest Public AMIs" \
+  --markdown-description-text "**WARNING! Do NOT use these AMIs in a production setting.** They are meant only to make
+    initial experiments with this module more convenient."

--- a/examples/influxdb-ami/influxdb.json
+++ b/examples/influxdb-ami/influxdb.json
@@ -7,7 +7,7 @@
   },
   "builders": [{
     "name": "influxdb-ami-ubuntu",
-    "ami_name": "{{user `base_ami_name`}}-ubuntu-example-{{isotime | clean_ami_name}}",
+    "ami_name": "{{user `base_ami_name`}}-ubuntu-example-{{uuid | clean_ami_name}}",
     "ami_description": "An Ubuntu 18.04 AMI that has InfluxDB Enterprise installed.",
     "instance_type": "t2.micro",
     "region": "{{user `aws_region`}}",
@@ -26,7 +26,7 @@
     "ssh_username": "ubuntu"
   },{
     "name": "influxdb-ami-amazon-linux",
-    "ami_name": "{{user `base_ami_name`}}-amazon-linux-example-{{isotime | clean_ami_name}}",
+    "ami_name": "{{user `base_ami_name`}}-amazon-linux-example-{{uuid | clean_ami_name}}",
     "ami_description": "An Amazon Linux 2 AMI that has InfluxDB Enterprise installed.",
     "instance_type": "t2.micro",
     "region": "{{user `aws_region`}}",

--- a/examples/influxdb-multi-cluster/main.tf
+++ b/examples/influxdb-multi-cluster/main.tf
@@ -40,8 +40,8 @@ data "aws_ami" "influxdb_ubuntu_example" {
   }
 }
 
-data "template_file" "ami_id" {
-  template = "${var.ami_id == "" ? data.aws_ami.influxdb_ubuntu_example.id : var.ami_id}"
+locals = {
+  ami_id = "${var.ami_id == "" ? data.aws_ami.influxdb_ubuntu_example.id : var.ami_id}"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -62,7 +62,7 @@ module "influxdb_meta_nodes" {
   # R4 or M4 instances.
   instance_type = "t2.micro"
 
-  ami_id    = "${data.template_file.ami_id.rendered}"
+  ami_id    = "${local.ami_id}"
   user_data = "${data.template_file.user_data_influxdb_meta_nodes.rendered}"
 
   vpc_id     = "${data.aws_vpc.default.id}"
@@ -119,7 +119,7 @@ module "influxdb_data_nodes" {
   # R4 or M4 instances.
   instance_type = "t2.micro"
 
-  ami_id    = "${data.template_file.ami_id.rendered}"
+  ami_id    = "${local.ami_id}"
   user_data = "${data.template_file.user_data_influxdb_data_nodes.rendered}"
 
   vpc_id     = "${data.aws_vpc.default.id}"

--- a/examples/influxdb-multi-cluster/main.tf
+++ b/examples/influxdb-multi-cluster/main.tf
@@ -10,6 +10,41 @@ provider "aws" {
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
+# USE THE PUBLIC EXAMPLE AMIS IF VAR.AMI_ID IS NOT SPECIFIED
+# We have published some example AMIs publicly that will be used if var.ami_id is not specified. This makes it easier
+# to try these examples out, but we recommend you build your own AMIs for production use.
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_ami" "influxdb_ubuntu_example" {
+  most_recent = true
+  owners      = ["087285199408"] # Gruntwork
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "image-type"
+    values = ["machine"]
+  }
+
+  filter {
+    name   = "name"
+    values = ["*influxdb-ubuntu-example*"]
+  }
+}
+
+data "template_file" "ami_id" {
+  template = "${var.ami_id == "" ? data.aws_ami.influxdb_ubuntu_example.id : var.ami_id}"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
 # DEPLOY THE INFLUXDB META NODES CLUSTER
 # ---------------------------------------------------------------------------------------------------------------------
 
@@ -27,7 +62,7 @@ module "influxdb_meta_nodes" {
   # R4 or M4 instances.
   instance_type = "t2.micro"
 
-  ami_id    = "${var.ami_id}"
+  ami_id    = "${data.template_file.ami_id.rendered}"
   user_data = "${data.template_file.user_data_influxdb_meta_nodes.rendered}"
 
   vpc_id     = "${data.aws_vpc.default.id}"
@@ -84,7 +119,7 @@ module "influxdb_data_nodes" {
   # R4 or M4 instances.
   instance_type = "t2.micro"
 
-  ami_id    = "${var.ami_id}"
+  ami_id    = "${data.template_file.ami_id.rendered}"
   user_data = "${data.template_file.user_data_influxdb_data_nodes.rendered}"
 
   vpc_id     = "${data.aws_vpc.default.id}"

--- a/examples/influxdb-multi-cluster/main.tf
+++ b/examples/influxdb-multi-cluster/main.tf
@@ -17,7 +17,7 @@ provider "aws" {
 
 data "aws_ami" "influxdb_ubuntu_example" {
   most_recent = true
-  owners      = ["087285199408"] # Gruntwork
+  owners      = ["562637147889"] # Gruntwork
 
   filter {
     name   = "virtualization-type"

--- a/examples/influxdb-multi-cluster/variables.tf
+++ b/examples/influxdb-multi-cluster/variables.tf
@@ -11,14 +11,6 @@
 # You must provide a value for each of these parameters.
 # ---------------------------------------------------------------------------------------------------------------------
 
-variable "aws_region" {
-  description = "The AWS region in which all resources will be created"
-}
-
-variable "ami_id" {
-  description = "The ID of the AMI to run in the cluster. This should be an AMI built from the Packer template under examples/influxdb-ami/influxdb.json."
-}
-
 variable "license_key" {
   description = "The key of your InfluxDB Enterprise license. This should not be set in plain-text and can be passed in as an env var or from a secrets management tool."
 }
@@ -31,6 +23,16 @@ variable "shared_secret" {
 # OPTIONAL PARAMETERS
 # These parameters have reasonable defaults.
 # ---------------------------------------------------------------------------------------------------------------------
+
+variable "aws_region" {
+  description = "The AWS region in which all resources will be created"
+  default     = "us-east-1"
+}
+
+variable "ami_id" {
+  description = "The ID of the AMI to run in the cluster. This should be an AMI built from the Packer template under examples/influxdb-ami/influxdb.json."
+  default     = ""
+}
 
 variable "api_port" {
   description = "The HTTP API port the Data nodes listen on for external communication."

--- a/main.tf
+++ b/main.tf
@@ -40,8 +40,8 @@ data "aws_ami" "influxdb_ubuntu_example" {
   }
 }
 
-data "template_file" "ami_id" {
-  template = "${var.ami_id == "" ? data.aws_ami.influxdb_ubuntu_example.id : var.ami_id}"
+locals = {
+  ami_id = "${var.ami_id == "" ? data.aws_ami.influxdb_ubuntu_example.id : var.ami_id}"
 }
 
 module "influxdb" {
@@ -58,7 +58,7 @@ module "influxdb" {
   # R4 or M4 instances.
   instance_type = "t2.micro"
 
-  ami_id    = "${data.template_file.ami_id.rendered}"
+  ami_id    = "${local.ami_id}"
   user_data = "${data.template_file.user_data_influxdb.rendered}"
 
   vpc_id     = "${data.aws_vpc.default.id}"

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ provider "aws" {
 
 data "aws_ami" "influxdb_ubuntu_example" {
   most_recent = true
-  owners      = ["087285199408"] # Gruntwork
+  owners      = ["562637147889"] # Gruntwork
 
   filter {
     name   = "virtualization-type"

--- a/test/influxdb_multi_cluster_test.go
+++ b/test/influxdb_multi_cluster_test.go
@@ -70,7 +70,7 @@ func TestInfluxDBMultiCluster(t *testing.T) {
 			})
 
 			test_structure.RunTestStage(t, "setup_ami", func() {
-				awsRegion := aws.GetRandomRegion(t, nil, nil)
+				awsRegion := aws.GetRandomRegion(t, []string{"us-east-1"}, nil)
 				amiID := buildAmi(t, templatePath, testCase.packerInfo.builderName, awsRegion)
 
 				uniqueID := strings.ToLower(random.UniqueId())

--- a/test/influxdb_single_cluster_test.go
+++ b/test/influxdb_single_cluster_test.go
@@ -70,7 +70,7 @@ func TestInfluxDBSingleCluster(t *testing.T) {
 			})
 
 			test_structure.RunTestStage(t, "setup_ami", func() {
-				awsRegion := aws.GetRandomRegion(t, nil, nil)
+				awsRegion := aws.GetRandomRegion(t, []string{"us-east-1"}, nil)
 				amiID := buildAmi(t, templatePath, testCase.packerInfo.builderName, awsRegion)
 
 				uniqueID := strings.ToLower(random.UniqueId())

--- a/variables.tf
+++ b/variables.tf
@@ -11,14 +11,6 @@
 # You must provide a value for each of these parameters.
 # ---------------------------------------------------------------------------------------------------------------------
 
-variable "aws_region" {
-  description = "The AWS region in which all resources will be created"
-}
-
-variable "ami_id" {
-  description = "The ID of the AMI to run in the cluster. This should be an AMI built from the Packer template under examples/influxdb-ami/influxdb.json."
-}
-
 variable "license_key" {
   description = "The key of your InfluxDB Enterprise license. This should not be set in plain-text and can be passed in as an env var or from a secrets management tool."
 }
@@ -31,6 +23,16 @@ variable "shared_secret" {
 # OPTIONAL PARAMETERS
 # These parameters have reasonable defaults.
 # ---------------------------------------------------------------------------------------------------------------------
+
+variable "aws_region" {
+  description = "The AWS region in which all resources will be created"
+  default     = "us-east-1"
+}
+
+variable "ami_id" {
+  description = "The ID of the AMI to run in the cluster. This should be an AMI built from the Packer template under examples/influxdb-ami/influxdb.json."
+  default     = ""
+}
 
 variable "influxdb_cluster_name" {
   description = "What to name the InfluxDB meta nodes cluster and all of its associated resources"


### PR DESCRIPTION
This PR makes it easy to get started with the examples by using a community AMI by default instead of requiring the user to build and supply an AMI ID. 