### PR TITLE
Install Telegraf

### DIFF
--- a/examples/telegraf-ami/README.md
+++ b/examples/telegraf-ami/README.md
@@ -9,6 +9,10 @@ Images (AMIs)](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) tha
 1. Ubuntu 18.04
 1. Amazon Linux 2
 
+Telegraf is usually installed as a collection agent on your application's EC2 instance(s).
+This Telegraf AMI is only useful for standing up Telegraf to pull remote data or accept data from a remote service,
+e.g. connecting to a queue like Kafka/PubSub or using it as a scraper to pull prometheus metrics.
+
 ## Quick start
 
 To build the Telegraf AMI:

--- a/examples/telegraf-ami/README.md
+++ b/examples/telegraf-ami/README.md
@@ -1,0 +1,67 @@
+# Telegraf AMI
+
+This folder shows an example of how to use the 
+[install-telegraf](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/modules/install-telegraf)
+modules with [Packer](https://www.packer.io/) to create [Amazon Machine 
+Images (AMIs)](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) that have 
+[Telegraf](https://www.influxdata.com/time-series-platform/telegraf/), and its dependencies installed on top of:
+ 
+1. Ubuntu 18.04
+1. Amazon Linux 2
+
+## Quick start
+
+To build the Telegraf AMI:
+
+1. `git clone` this repo to your computer.
+1. Install [Packer](https://www.packer.io/).
+1. Configure your AWS credentials using one of the [options supported by the AWS 
+   SDK](http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html). Usually, the easiest option is to
+   set the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
+1. Update the `variables` section of the `telegraf.json` Packer template to specify the AWS region and Telegraf
+   version you wish to use.
+1. To build an Ubuntu AMI for Telegraf: `packer build -only=telegraf-ami-ubuntu telegraf.json`.
+1. To build an Amazon Linux AMI for Telegraf: `packer build -only=telegraf-ami-amazon-linux telegraf.json`.
+
+## Creating your own Packer template for production usage
+
+When creating your own Packer template for production usage, you can copy the example in this folder more or less 
+exactly, except for one change: we recommend replacing the `file` provisioner with a call to `git clone` in a `shell` 
+provisioner. Instead of:
+
+```json
+{
+  "provisioners": [{
+    "type": "file",
+    "source": "{{template_dir}}/../../../terraform-aws-influx",
+    "destination": "/tmp"
+  },{
+    "type": "shell",
+    "inline": [
+      "/tmp/terraform-aws-influx/modules/install-telegraf/install-telegraf --version {{user `version`}}"
+    ],
+    "pause_before": "30s"
+  }]
+}
+```
+
+Your code should look more like this:
+
+```json
+{
+  "provisioners": [{
+    "type": "shell",
+    "inline": [
+      "git clone --branch <MODULE_VERSION> https://github.com/gruntwork-io/terraform-aws-influx.git /tmp/terraform-aws-influx",
+      "/tmp/terraform-aws-influx/modules/install-telegraf/install-telegraf --version {{user `version`}}"
+    ],
+    "pause_before": "30s"
+  }]
+}
+```
+
+You should replace `<MODULE_VERSION>` in the code above with the version of this module that you want to use (see
+the [Releases Page](https://github.com/gruntwork-io/terraform-aws-influx/releases) for all available versions). 
+That's because for production usage, you should always use a fixed, known version of this Module, downloaded from the 
+official Git repo via `git clone`. On the other hand, when you're just experimenting with the Module, it's OK to use a 
+local checkout of the Module, uploaded from your own computer via the `file` provisioner.

--- a/examples/telegraf-ami/config/telegraf.conf
+++ b/examples/telegraf-ami/config/telegraf.conf
@@ -1,0 +1,142 @@
+# Telegraf Configuration
+#
+# Telegraf is entirely plugin driven. All metrics are gathered from the
+# declared inputs, and sent to the declared outputs.
+#
+# Plugins must be declared in here to be active.
+# To deactivate a plugin, comment out the name and any variables.
+#
+# Use 'telegraf -config telegraf.conf -test' to see what metrics a config
+# file would generate.
+#
+# Environment variables can be used anywhere in this config file, simply prepend
+# them with $. For strings the variable must be within quotes (ie, "$STR_VAR"),
+# for numbers and booleans they should be plain (ie, $INT_VAR, $BOOL_VAR)
+
+
+# Global tags can be specified here in key="value" format.
+[global_tags]
+  # dc = "us-east-1" # will tag all metrics with dc=us-east-1
+  # rack = "1a"
+  ## Environment variables can be used as tags, and throughout the config file
+  # user = "$USER"
+
+
+# Configuration for telegraf agent
+[agent]
+  ## Default data collection interval for all inputs
+  interval = "10s"
+  ## Rounds collection interval to 'interval'
+  ## ie, if interval="10s" then always collect on :00, :10, :20, etc.
+  round_interval = true
+
+  ## Telegraf will send metrics to outputs in batches of at most
+  ## metric_batch_size metrics.
+  ## This controls the size of writes that Telegraf sends to output plugins.
+  metric_batch_size = 1000
+
+  ## For failed writes, telegraf will cache metric_buffer_limit metrics for each
+  ## output, and will flush this buffer on a successful write. Oldest metrics
+  ## are dropped first when this buffer fills.
+  ## This buffer only fills when writes fail to output plugin(s).
+  metric_buffer_limit = 10000
+
+  ## Collection jitter is used to jitter the collection by a random amount.
+  ## Each plugin will sleep for a random time within jitter before collecting.
+  ## This can be used to avoid many plugins querying things like sysfs at the
+  ## same time, which can have a measurable effect on the system.
+  collection_jitter = "0s"
+
+  ## Default flushing interval for all outputs. Maximum flush_interval will be
+  ## flush_interval + flush_jitter
+  flush_interval = "10s"
+  ## Jitter the flush interval by a random amount. This is primarily to avoid
+  ## large write spikes for users running a large number of telegraf instances.
+  ## ie, a jitter of 5s and interval 10s means flushes will happen every 10-15s
+  flush_jitter = "0s"
+
+  ## By default or when set to "0s", precision will be set to the same
+  ## timestamp order as the collection interval, with the maximum being 1s.
+  ##   ie, when interval = "10s", precision will be "1s"
+  ##       when interval = "250ms", precision will be "1ms"
+  ## Precision will NOT be used for service inputs. It is up to each individual
+  ## service input to set the timestamp at the appropriate precision.
+  ## Valid time units are "ns", "us" (or "µs"), "ms", "s".
+  precision = ""
+
+  ## Logging configuration:
+  ## Run telegraf with debug log messages.
+  debug = false
+  ## Run telegraf in quiet mode (error log messages only).
+  quiet = false
+  ## Specify the log file name. The empty string means to log to stderr.
+  logfile = ""
+
+  ## Override default hostname, if empty use os.Hostname()
+  hostname = ""
+  ## If set to true, do no set the "host" tag in the telegraf agent.
+  omit_hostname = false
+
+
+###############################################################################
+#                            OUTPUT PLUGINS                                   #
+###############################################################################
+
+# Configuration for sending metrics to InfluxDB
+[[outputs.influxdb]]
+  ## The full HTTP or UDP URL for your InfluxDB instance.
+  urls = ["<__INFLUXDB_URL__>"]
+
+  ## The target database for metrics; will be created as needed.
+  database = "<__DATABASE_NAME__>"
+
+  ## If true, no CREATE DATABASE queries will be sent.  Set to true when using
+  ## Telegraf with a user without permissions to create databases or when the
+  ## database already exists.
+  skip_database_creation = false
+
+###############################################################################
+#                            INPUT PLUGINS                                    #
+###############################################################################
+
+# Read metrics about cpu usage
+[[inputs.cpu]]
+  ## Whether to report per-cpu stats or not
+  percpu = true
+  ## Whether to report total system cpu stats or not
+  totalcpu = true
+  ## If true, collect raw CPU time metrics.
+  collect_cpu_time = false
+  ## If true, compute and report the sum of all non-idle CPU states.
+  report_active = false
+
+
+# Read metrics about disk usage by mount point
+[[inputs.disk]]
+  ## By default stats will be gathered for all mount points.
+  ## Set mount_points will restrict the stats to only the specified mount points.
+  # mount_points = ["/"]
+
+  ## Ignore mount points by filesystem type.
+  ignore_fs = ["tmpfs", "devtmpfs", "devfs", "overlay", "aufs", "squashfs"]
+
+
+# Get kernel statistics from /proc/stat
+[[inputs.kernel]]
+  # no configuration
+
+
+# Read metrics about memory usage
+[[inputs.mem]]
+  # no configuration
+
+
+# Get the number of processes and group them by status
+[[inputs.processes]]
+  # no configuration
+
+
+# Read metrics about system load & uptime
+[[inputs.system]]
+  # no configuration
+

--- a/examples/telegraf-ami/telegraf.json
+++ b/examples/telegraf-ami/telegraf.json
@@ -1,0 +1,104 @@
+{
+  "min_packer_version": "0.12.0",
+  "variables": {
+    "aws_region": "us-east-1",
+    "base_ami_name": "telegraf",
+    "version": "1.9.4"
+  },
+  "builders": [{
+    "name": "telegraf-ami-ubuntu",
+    "ami_name": "{{user `base_ami_name`}}-ubuntu-example-{{uuid | clean_ami_name}}",
+    "ami_description": "An Ubuntu 18.04 AMI that has Telegraf installed.",
+    "instance_type": "t2.micro",
+    "region": "{{user `aws_region`}}",
+    "type": "amazon-ebs",
+    "source_ami_filter": {
+      "filters": {
+        "virtualization-type": "hvm",
+        "architecture": "x86_64",
+        "name": "*ubuntu-bionic-18.04-amd64-server-*",
+        "block-device-mapping.volume-type": "gp2",
+        "root-device-type": "ebs"
+      },
+      "owners": ["099720109477"],
+      "most_recent": true
+    },
+    "ssh_username": "ubuntu"
+  },{
+    "name": "telegraf-ami-amazon-linux",
+    "ami_name": "{{user `base_ami_name`}}-amazon-linux-example-{{uuid | clean_ami_name}}",
+    "ami_description": "An Amazon Linux 2 AMI that has Telegraf installed.",
+    "instance_type": "t2.micro",
+    "region": "{{user `aws_region`}}",
+    "type": "amazon-ebs",
+    "source_ami_filter": {
+      "filters": {
+        "virtualization-type": "hvm",
+        "architecture": "x86_64",
+        "name": "amzn2-ami-hvm-*-x86_64-gp2",
+        "block-device-mapping.volume-type": "gp2",
+        "root-device-type": "ebs"
+      },
+      "owners": ["amazon"],
+      "most_recent": true
+    },
+    "ssh_username": "ec2-user"
+  },{
+    "name": "telegraf-docker-ubuntu",
+    "type": "docker",
+    "image": "ubuntu:18.04",
+    "commit": "true"
+  },{
+    "name": "telegraf-docker-amazon-linux",
+    "type": "docker",
+    "image": "amazonlinux:2",
+    "commit": "true"
+  }],
+  "provisioners": [{
+    "type": "shell",
+    "inline": [
+      "DEBIAN_FRONTEND=noninteractive apt-get update -y",
+      "apt-get install -y sudo wget git systemd"
+    ],
+    "only": ["telegraf-docker-ubuntu"]
+  },{
+    "type": "shell",
+    "inline": [
+      "yum update -y",
+      "yum install -y sudo wget git"
+    ],
+    "only": ["telegraf-docker-amazon-linux"]
+  },{
+    "type": "shell",
+    "inline": [
+      "sudo mkdir -p /opt/gruntwork",
+      "git clone --branch v0.0.7 https://github.com/gruntwork-io/bash-commons.git /tmp/bash-commons",
+      "sudo cp -r /tmp/bash-commons/modules/bash-commons/src /opt/gruntwork/bash-commons",
+      "mkdir -p /tmp/terraform-aws-influx"
+    ]
+  },{
+    "type": "file",
+    "source": "{{template_dir}}/config",
+    "destination": "/tmp"
+  },{
+    "type": "file",
+    "source": "{{template_dir}}/../../",
+    "destination": "/tmp/terraform-aws-influx"
+  },{
+    "type": "shell",
+    "inline": [
+      "/tmp/terraform-aws-influx/modules/install-telegraf/install-telegraf --version {{user `version`}}"
+    ]
+  }],
+  "post-processors": [{
+    "type": "docker-tag",
+    "repository": "gruntwork/telegraf-ubuntu",
+    "tag": "latest",
+    "only": ["telegraf-docker-ubuntu"]
+  },{
+    "type": "docker-tag",
+    "repository": "gruntwork/influxdb-amazon-linux",
+    "tag": "latest",
+    "only": ["telegraf-docker-amazon-linux"]
+  }]
+}

--- a/examples/telegraf-ami/telegraf.json
+++ b/examples/telegraf-ami/telegraf.json
@@ -72,7 +72,7 @@
     "type": "shell",
     "inline": [
       "sudo mkdir -p /opt/gruntwork",
-      "git clone --branch v0.0.7 https://github.com/gruntwork-io/bash-commons.git /tmp/bash-commons",
+      "git clone --branch v0.1.0 https://github.com/gruntwork-io/bash-commons.git /tmp/bash-commons",
       "sudo cp -r /tmp/bash-commons/modules/bash-commons/src /opt/gruntwork/bash-commons",
       "mkdir -p /tmp/terraform-aws-influx"
     ]

--- a/modules/install-telegraf/install-telegraf
+++ b/modules/install-telegraf/install-telegraf
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Import the appropriate bash commons libraries
+readonly BASH_COMMONS_DIR="/opt/gruntwork/bash-commons"
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+readonly DEFAULT_TELEGRAF_VERSION="1.9.4"
+readonly DEFAULT_TEMP_TELEGRAF_CONFIG_FILE_PATH="/tmp/config/telegraf.conf"
+readonly DEFAULT_TELEGRAF_CONFIG_FILE_PATH="/etc/telegraf/telegraf.conf"
+readonly DEFAULT_TELEGRAF_DIR="/opt/telegraf"
+readonly DEFAULT_TELEGRAF_BIN_DIR="$DEFAULT_TELEGRAF_DIR/bin"
+
+if [[ ! -d "$BASH_COMMONS_DIR" ]]; then
+  echo "ERROR: this script requires that bash-commons is installed in $BASH_COMMONS_DIR. See https://github.com/gruntwork-io/bash-commons for more info."
+  exit 1
+fi
+
+source "$BASH_COMMONS_DIR/assert.sh"
+source "$BASH_COMMONS_DIR/log.sh"
+source "$BASH_COMMONS_DIR/os.sh"
+
+function print_usage {
+  echo
+  echo "Usage: install-telegraf [options]"
+  echo
+  echo "This script can be used to install Telegraf and its dependencies. This script has been tested with Ubuntu 18.04 and Amazon Linux 2."
+  echo
+  echo "Options:"
+  echo
+  echo -e "  --version\t\tThe version of InfluxDB Enterprise to install. Default: $DEFAULT_TELEGRAF_VERSION."
+  echo -e "  --config-file\t\tPath to a custom configuration file. Default: $DEFAULT_TEMP_TELEGRAF_CONFIG_FILE_PATH"
+
+  echo
+  echo "Example:"
+  echo
+  echo "  install-telegraf  --version $DEFAULT_TELEGRAF_VERSION --config-file $DEFAULT_TEMP_TELEGRAF_CONFIG_FILE_PATH"
+}
+
+function install_telegraf_on_ubuntu {
+  local -r version="$1"
+
+  log_info "Installing Telegraf"
+  wget https://dl.influxdata.com/telegraf/releases/telegraf_${version}-1_amd64.deb
+  sudo dpkg -i "telegraf_${version}-1_amd64.deb"
+}
+
+function install_telegraf_on_amazon_linux {
+  local -r version="$1"
+
+  log_info "Installing Telegraf"
+  wget "https://dl.influxdata.com/telegraf/releases/telegraf-${version}-1.x86_64.rpm"
+  sudo yum localinstall -y "telegraf-${version}-1.x86_64.rpm"
+}
+
+function install_telegraf {
+  local version="$DEFAULT_TELEGRAF_VERSION"
+  local config_file="$DEFAULT_TEMP_TELEGRAF_CONFIG_FILE_PATH"
+
+  while [[ $# > 0 ]]; do
+    local key="$1"
+
+    case "$key" in
+      --help)
+        print_usage
+        exit
+        ;;
+      --version)
+        assert_not_empty "$key" "$2"
+        version="$2"
+        shift
+        ;;
+      --config-file)
+        assert_not_empty "$key" "$2"
+        config_file="$2"
+        shift
+        ;;
+      *)
+        echo "Unrecognized argument: $key"
+        print_usage
+        exit 1
+        ;;
+    esac
+
+    shift
+  done
+
+  assert_is_installed "sudo"
+  assert_is_installed "wget"
+
+  if os_is_ubuntu "18.04"; then
+    install_telegraf_on_ubuntu "$version"
+  elif os_is_amazon_linux "2"; then
+    install_telegraf_on_amazon_linux "$version"
+  else
+    log_error "This script only supports Ubuntu 18.04 and Amazon Linux 2."
+    exit 1
+  fi
+
+  sudo mv "$config_file" "$DEFAULT_TELEGRAF_CONFIG_FILE_PATH"
+}
+
+install_telegraf "$@"

--- a/modules/install-telegraf/install-telegraf
+++ b/modules/install-telegraf/install-telegraf
@@ -42,7 +42,7 @@ function install_telegraf_on_ubuntu {
   local -r version="$1"
 
   log_info "Installing Telegraf"
-  wget https://dl.influxdata.com/telegraf/releases/telegraf_${version}-1_amd64.deb
+  wget "https://dl.influxdata.com/telegraf/releases/telegraf_${version}-1_amd64.deb"
   sudo dpkg -i "telegraf_${version}-1_amd64.deb"
 }
 

--- a/test/influxdb_multi_cluster_test.go
+++ b/test/influxdb_multi_cluster_test.go
@@ -70,7 +70,7 @@ func TestInfluxDBMultiCluster(t *testing.T) {
 			})
 
 			test_structure.RunTestStage(t, "setup_ami", func() {
-				awsRegion := aws.GetRandomRegion(t, nil, nil)
+				awsRegion := aws.GetRandomRegion(t, nil, []string{"eu-north-1"})
 				amiID := buildAmi(t, templatePath, testCase.packerInfo.builderName, awsRegion)
 
 				uniqueID := strings.ToLower(random.UniqueId())

--- a/test/influxdb_single_cluster_test.go
+++ b/test/influxdb_single_cluster_test.go
@@ -70,7 +70,7 @@ func TestInfluxDBSingleCluster(t *testing.T) {
 			})
 
 			test_structure.RunTestStage(t, "setup_ami", func() {
-				awsRegion := aws.GetRandomRegion(t, nil, nil)
+				awsRegion := aws.GetRandomRegion(t, nil, []string{"eu-north-1"})
 				amiID := buildAmi(t, templatePath, testCase.packerInfo.builderName, awsRegion)
 
 				uniqueID := strings.ToLower(random.UniqueId())


### PR DESCRIPTION
This PR contains the `install-telegraf` script for installing Telegraf on Amazon Linux 2 and Ubuntu 18.04. It also contains an example AMI