### PR TITLE
Telegraf Run Module

### DIFF
--- a/examples/telegraf-ami/telegraf.json
+++ b/examples/telegraf-ami/telegraf.json
@@ -57,6 +57,13 @@
   "provisioners": [{
     "type": "shell",
     "inline": [
+      "sudo yum update -y",
+      "sudo yum install -y git"
+    ],
+    "only": ["telegraf-ami-amazon-linux"]
+  },{
+    "type": "shell",
+    "inline": [
       "DEBIAN_FRONTEND=noninteractive apt-get update -y",
       "apt-get install -y sudo wget git systemd"
     ],
@@ -74,7 +81,7 @@
       "sudo mkdir -p /opt/gruntwork",
       "git clone --branch v0.1.0 https://github.com/gruntwork-io/bash-commons.git /tmp/bash-commons",
       "sudo cp -r /tmp/bash-commons/modules/bash-commons/src /opt/gruntwork/bash-commons",
-      "mkdir -p /tmp/terraform-aws-influx"
+      "mkdir -p /tmp/terraform-aws-influx/modules"
     ]
   },{
     "type": "file",
@@ -82,8 +89,8 @@
     "destination": "/tmp"
   },{
     "type": "file",
-    "source": "{{template_dir}}/../../",
-    "destination": "/tmp/terraform-aws-influx"
+    "source": "{{template_dir}}/../../modules/",
+    "destination": "/tmp/terraform-aws-influx/modules"
   },{
     "type": "shell",
     "inline": [

--- a/modules/install-telegraf/install-telegraf
+++ b/modules/install-telegraf/install-telegraf
@@ -29,7 +29,7 @@ function print_usage {
   echo
   echo "Options:"
   echo
-  echo -e "  --version\t\tThe version of InfluxDB Enterprise to install. Default: $DEFAULT_TELEGRAF_VERSION."
+  echo -e "  --version\t\tThe version of Telegraf to install. Default: $DEFAULT_TELEGRAF_VERSION."
   echo -e "  --config-file\t\tPath to a custom configuration file. Default: $DEFAULT_TEMP_TELEGRAF_CONFIG_FILE_PATH"
 
   echo
@@ -52,6 +52,17 @@ function install_telegraf_on_amazon_linux {
   log_info "Installing Telegraf"
   wget "https://dl.influxdata.com/telegraf/releases/telegraf-${version}-1.x86_64.rpm"
   sudo yum localinstall -y "telegraf-${version}-1.x86_64.rpm"
+}
+
+function install_telegraf_scripts {
+  local -r dest_dir="$1"
+
+  local -r run_telegraf_src="$SCRIPT_DIR/../run-telegraf/run-telegraf"
+  local -r run_telegraf_dest="$dest_dir/run-telegraf"
+
+  log_info "Copying $run_telegraf_src to $run_telegraf_dest"
+  sudo mkdir -p "$dest_dir"
+  sudo cp "$run_telegraf_src" "$run_telegraf_dest"
 }
 
 function install_telegraf {
@@ -98,7 +109,11 @@ function install_telegraf {
     exit 1
   fi
 
+  # Disable the installed systemd service to prevent it from starting up on boot
+  sudo systemctl disable telegraf.service
+
   sudo mv "$config_file" "$DEFAULT_TELEGRAF_CONFIG_FILE_PATH"
+  install_telegraf_scripts "$DEFAULT_TELEGRAF_BIN_DIR"
 }
 
 install_telegraf "$@"

--- a/modules/install-telegraf/install-telegraf
+++ b/modules/install-telegraf/install-telegraf
@@ -109,7 +109,8 @@ function install_telegraf {
     exit 1
   fi
 
-  # Disable the installed systemd service to prevent it from starting up on boot
+  # Disable the installed systemd service to prevent it from starting up on boot.
+  # The 'run-telegraf' script will be used to start the service after properly configuring it
   sudo systemctl disable telegraf.service
 
   sudo mv "$config_file" "$DEFAULT_TELEGRAF_CONFIG_FILE_PATH"

--- a/modules/run-telegraf/README.md
+++ b/modules/run-telegraf/README.md
@@ -52,7 +52,7 @@ Options:
 
 Example:
 
-  run-telegraf --auto-fill '<__INFLUXDB_URL__>=http://localhost:8086'
+  run-telegraf --auto-fill '<__INFLUXDB_URL__>=http://localhost:8086' --auto-fill '<__DATABASE_NAME__>=telegraf'
 ```
 
 ## Debugging tips and tricks

--- a/modules/run-telegraf/run-telegraf
+++ b/modules/run-telegraf/run-telegraf
@@ -13,6 +13,7 @@ fi
 
 source "$BASH_COMMONS_DIR/assert.sh"
 source "$BASH_COMMONS_DIR/file.sh"
+source "$BASH_COMMONS_DIR/log.sh"
 
 function print_usage {
   echo
@@ -52,6 +53,10 @@ function run_telegraf {
   done
 
   file_fill_template "$DEFAULT_TELEGRAF_CONFIG_FILE_PATH" "${auto_fill[@]}"
+
+  log_info "Starting Telegraf"
+  sudo systemctl enable telegraf.service
+  sudo systemctl start telegraf.service
 }
 
 run_telegraf "$@"

--- a/modules/run-telegraf/run-telegraf
+++ b/modules/run-telegraf/run-telegraf
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Import the appropriate bash commons libraries
+readonly BASH_COMMONS_DIR="/opt/gruntwork/bash-commons"
+readonly DEFAULT_TELEGRAF_CONFIG_FILE_PATH="/etc/telegraf/telegraf.conf"
+
+if [[ ! -d "$BASH_COMMONS_DIR" ]]; then
+  echo "ERROR: this script requires that bash-commons is installed in $BASH_COMMONS_DIR. See https://github.com/gruntwork-io/bash-commons for more info."
+  exit 1
+fi
+
+source "$BASH_COMMONS_DIR/assert.sh"
+source "$BASH_COMMONS_DIR/file.sh"
+
+function print_usage {
+  echo
+  echo "Usage: run-telegraf [options]"
+  echo
+  echo "This script can be used to configure and initialize Telegraf. This script has been tested with Ubuntu 18.04 and Amazon Linux 2."
+  echo
+  echo "Options:"
+  echo
+  echo -e "  --auto-fill\tSearch the Telegraf config file for KEY and replace it with VALUE. May be repeated."
+
+  echo
+  echo "Example:"
+  echo
+  echo "  run-telegraf --auto-fill '<__INFLUXDB_URL__>=http://localhost:8086' --auto-fill '<__DATABASE_NAME__>=telegraf'"
+}
+
+function run_telegraf {
+  local -a auto_fill=()
+
+  while [[ $# > 0 ]]; do
+    local key="$1"
+    case "$key" in
+      --auto-fill)
+        assert_not_empty "$key" "$2"
+        auto_fill+=("$2")
+        shift
+        ;;
+      *)
+        echo "Unrecognized argument: $key"
+        print_usage
+        exit 1
+        ;;
+    esac
+
+    shift
+  done
+
+  file_fill_template "$DEFAULT_TELEGRAF_CONFIG_FILE_PATH" "${auto_fill[@]}"
+}
+
+run_telegraf "$@"


### PR DESCRIPTION
This PR does the following:

* Include `run-telegraf` script to update the config and start up the Telegraf service
* Update `install-telegraf` script to install `run-telegraf` script in `/opt/telegraf/bin`
* Update `install-telegraf` script to disable Telegraf service so it doesn't start up on first instance boot