### PR TITLE
Kapacitor RDD

### DIFF
--- a/examples/tick-ami/tick.json
+++ b/examples/tick-ami/tick.json
@@ -28,7 +28,7 @@
   },{
     "name": "tick-ami-amazon-linux",
     "ami_name": "{{user `base_ami_name`}}-amazon-linux-example-{{uuid | clean_ami_name}}",
-    "ami_description": "An Amazon Linux 2 AMI that has the TICK installed.",
+    "ami_description": "An Amazon Linux 2 AMI that has the TICK stack installed.",
     "instance_type": "t2.micro",
     "region": "{{user `aws_region`}}",
     "type": "amazon-ebs",

--- a/modules/install-kapacitor/README.md
+++ b/modules/install-kapacitor/README.md
@@ -1,6 +1,6 @@
 # Kapacitor Install Script
 
-Kapacitor is is a Real-Time Streaming Data Processing Engine
+Kapacitor is a Real-Time Streaming Data Processing Engine.
 This folder contains a script for installing Kapacitor Enterprise and its dependencies.
 
 This script has been tested on the following operating systems:

--- a/modules/install-kapacitor/README.md
+++ b/modules/install-kapacitor/README.md
@@ -1,0 +1,64 @@
+# Kapacitor Install Script
+
+Kapacitor is is a Real-Time Streaming Data Processing Engine
+This folder contains a script for installing Kapacitor Enterprise and its dependencies.
+
+This script has been tested on the following operating systems:
+
+* Ubuntu 16.04
+* Amazon Linux 2
+
+There is a good chance it will work on other flavors of Debian, CentOS, and RHEL as well.
+
+## Quick start
+
+This module depends on [bash-commons](https://github.com/gruntwork-io/bash-commons), so you must install that project
+first as documented in its README.
+
+The easiest way to use this module is with the [Gruntwork Installer](https://github.com/gruntwork-io/gruntwork-installer):
+
+```bash
+gruntwork-install \
+  --module-name "install-kapacitor" \
+  --repo "https://github.com/gruntwork-io/terraform-aws-influx" \
+  --tag "<VERSION>"
+```
+
+Checkout the [releases](https://github.com/gruntwork-io/terraform-aws-influx/releases) to find the latest version.
+
+The `install-kapacitor` script will install the Kapacitor Enterprise binary as well as its dependencies.
+
+We recommend running the `install-kapacitor` script as part of a [Packer](https://www.packer.io/) template to 
+create a Kapacitor [Amazon Machine Image (AMI)](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html).
+You can then deploy the AMI across an Auto Scaling Group using the [kapacitor-cluster 
+module](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/modules/kapacitor-cluster) (see the 
+[examples folder](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/examples) for fully-working sample code).
+
+
+## Command line Arguments
+
+Run `install-kapacitor --help` to see all available arguments.
+
+```
+Usage: install-kapacitor [options]
+
+This script can be used to install Kapacitor Enterprise and its dependencies. This script has been tested with Ubuntu 18.04 and Amazon Linux 2.
+
+Options:
+
+  --version       The version of Kapacitor to install. Default: 1.5.2.
+  --config-file   Path to a custom configuration file. Default: /tmp/config/kapacitor.conf
+
+Example:
+
+  install-kapacitor \
+    --version 1.5.2 \
+    --config-file /tmp/config/kapacitor.conf
+```
+
+## How it works
+
+The `install-kapacitor` script does the following:
+
+1. Installs the Kapacitor Enterprise binary
+1. Replaces the default Kapatictor config file with your custom config file.

--- a/modules/install-kapacitor/README.md
+++ b/modules/install-kapacitor/README.md
@@ -5,7 +5,7 @@ This folder contains a script for installing Kapacitor Enterprise and its depend
 
 This script has been tested on the following operating systems:
 
-* Ubuntu 16.04
+* Ubuntu 18.04
 * Amazon Linux 2
 
 There is a good chance it will work on other flavors of Debian, CentOS, and RHEL as well.

--- a/modules/kapacitor-cluster/README.md
+++ b/modules/kapacitor-cluster/README.md
@@ -1,0 +1,127 @@
+# Kapacitor Cluster
+
+This folder contains a [Terraform](https://www.terraform.io/) module to deploy an [Kapacitor Enterprise](
+https://www.influxdata.com/time-series-platform/kapacitor/) cluster in [AWS](https://aws.amazon.com/) on top of an Auto Scaling Group. 
+The idea is to create an [Amazon Machine Image (AMI)](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html)
+that has Kapacitor binaries installed using the [install-kapacitor](
+https://github.com/gruntwork-io/terraform-aws-influx/tree/master/modules/install-kapacitor) module.
+
+## How do you use this module?
+
+This folder defines a [Terraform module](https://www.terraform.io/docs/modules/usage.html), which you can use in your
+code by adding a `module` configuration and setting its `source` parameter to URL of this folder:
+
+```hcl
+module "kapacitor_cluster" {
+  # TODO: replace <VERSION> with the latest version from the releases page: https://github.com/gruntwork-io/terraform-aws-influx/releases
+  source = "github.com/gruntwork-io/terraform-aws-influx//modules/kapacitor-cluster?ref=<VERSION>"
+
+  # Specify the ID of the Kapacitor AMI. You should build this using the scripts in the install-kapacitor module.
+  ami_id = "ami-abcd1234"
+  
+  # Configure and start Kapacitor during boot. 
+  user_data = <<-EOF
+              #!/bin/bash
+              sudo systemctl start kapacitor
+              EOF
+  
+  # ... See variables.tf for the other parameters you must define for the kapacitor-cluster module
+}
+```
+
+Note the following parameters:
+
+* `source`: Use this parameter to specify the URL of the kapacitor-cluster module. The double slash (`//`) is 
+  intentional and required. Terraform uses it to specify subfolders within a Git repo (see [module 
+  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in 
+  this repo. That way, instead of using the latest version of this module from the `master` branch, which 
+  will change every time you run Terraform, you're using a fixed version of the repo.
+
+* `ami_id`: Use this parameter to specify the ID of an Kapacitor [Amazon Machine Image 
+  (AMI)](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) to deploy on each server in the cluster. You
+  should install Kapacitor the scripts in the 
+  [install-kapacitor](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/modules/install-kapacitor) module.
+  
+* `user_data`: Use this parameter to specify a [User 
+  Data](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html#user-data-shell-scripts) script that each
+  server will run during boot. This is where you can use the 
+  [run-kapacitor](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/modules/run-kapacitor) 
+  script to configure and run Kapacitor. 
+
+You can find the other parameters in [variables.tf](variables.tf).
+
+Check out the [examples folder](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/examples) for 
+fully-working sample code.
+
+## Why Kapacitor enterprise?
+
+Unlike the Enterprise edition which distributes the entire Kapacitor deployment across multiple nodes in a cluster,
+the OSS edition is a single binary that can simply be installed on a single instance. This makes a robust module like this one
+quite unnecessary for single instance Kapacitor OSS deployments.
+
+## What's included in this module?
+
+This module creates the following:
+
+* [Auto Scaling Group](#auto-scaling-group)
+* [Security Group](#security-group)
+* [IAM Role and Permissions](#iam-role-and-permissions)
+
+### Auto Scaling Group
+
+This module runs Kapacitor on top of an [Auto Scaling Group (ASG)](https://aws.amazon.com/autoscaling/). Typically, you
+should run the ASG with multiple Instances spread across multiple [Availability 
+Zones](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html). Each of the EC2
+Instances should be running an AMI that has Kapacitor installed via the 
+[install-kapacitor](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/modules/install-kapacitor)
+module. You pass in the ID of the AMI to run using the `ami_id` input parameter.
+
+
+### Security Group
+
+Each EC2 Instance in the ASG has a Security Group that allows minimal connectivity:
+
+* All outbound requests
+* Inbound SSH access from the CIDR blocks and security groups you specify
+
+The Security Group ID is exported as an output variable which you can use with the 
+[kapacitor-security-group-rules](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/modules/kapacitor-security-group-rules)
+module to open up all the ports necessary for Kapacitor.
+
+### IAM Role and Permissions
+
+Each EC2 Instance in the ASG has an [IAM Role](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) attached. 
+The IAM Role ARN and ID are exported as output variables if you need to add additional permissions.
+
+### How do you roll out updates?
+
+This module currently doesn't support updating the version of Kapacitor installed across the cluster. You can however follow
+this [guide](https://docs.influxdata.com/kapacitor/v1.5/administration/upgrading/) to manually perform the upgrade.
+
+### Dedicated instances
+
+If you wish to use dedicated instances, you can set the `tenancy` parameter to `"dedicated"` in this module. 
+
+### Encryption
+
+This module does not currently support specifying encryption information. The official [documentation](
+https://docs.influxdata.com/enterprise_kapacitor/v1.5/administration/security/#kapacitor-enterprise-over-tls) contains a guide for enabling SSL.
+
+### Security groups
+
+This module attaches a security group to each EC2 Instance that allows inbound requests as follows:
+
+* **SSH**: For the SSH port (default: 22), you can use the `allowed_ssh_cidr_blocks` parameter to control the list of   
+  [CIDR blocks](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) that will be allowed access. You can use 
+  the `allowed_inbound_ssh_security_group_ids` parameter to control the list of source Security Groups that will be 
+  allowed access.
+  
+The ID of the security group is exported as an output variable, which you can use with the 
+[kapacitor-security-group-rules](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/modules/kapacitor-security-group-rules)
+module to open up all the ports necessary for Kapacitor.
+
+### SSH access
+
+You can associate an [EC2 Key Pair](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) with each
+of the EC2 Instances in this cluster by specifying the Key Pair's name in the `ssh_key_name` variable. If you don't
+want to associate a Key Pair with these servers, set `ssh_key_name` to an empty string.

--- a/modules/kapacitor-cluster/README.md
+++ b/modules/kapacitor-cluster/README.md
@@ -53,11 +53,11 @@ You can find the other parameters in [variables.tf](variables.tf).
 Check out the [examples folder](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/examples) for 
 fully-working sample code.
 
-## Why Kapacitor enterprise?
+## Why Kapacitor Enterprise?
 
-Unlike the Enterprise edition which distributes the entire Kapacitor deployment across multiple nodes in a cluster,
-the OSS edition is a single binary that can simply be installed on a single instance. This makes a robust module like this one
-quite unnecessary for single instance Kapacitor OSS deployments.
+The Enterprise edition of Kapacitor is the only flavor that supports deployment across multiple nodes in a luster. The OSS edition
+is distributed as a single binary to be installed on a single instance. This makes a robust module like this one only useful for
+the cluster deployment capacilities of the enterprise edition.
 
 ## What's included in this module?
 

--- a/modules/kapacitor-iam-policies/README.md
+++ b/modules/kapacitor-iam-policies/README.md
@@ -1,0 +1,47 @@
+# Kapacitor IAM Policies
+
+This folder contains a [Terraform](https://www.terraform.io/) module that defines the IAM Policies used by an
+[Kapacitor Enterprise](https://www.influxdata.com/time-series-platform/kapacitor/) cluster.
+These policies are defined in a separate module so that you can add them to any existing IAM Role. 
+
+## Quick start
+
+Let's say you want to deploy Kapacitor using the [kapacitor-cluster 
+module](https://github.com/gruntwork-io/terraform-aws-influx/blob/master/modules/kapacitor-cluster): 
+
+```hcl
+module "kapacitor" {
+  # TODO: replace <VERSION> with the latest version from the releases page: https://github.com/gruntwork-io/terraform-aws-influx/releases
+  source = "github.com/gruntwork-io/terraform-aws-influx//modules/kapacitor-cluster?ref=<VERSION>"
+
+  # ... (other params omitted) ...
+}
+```
+
+You can attach the IAM policies to this cluster as follows:
+
+```hcl
+module "kapacitor_iam_policies" {
+  # TODO: replace <VERSION> with the latest version from the releases page: https://github.com/gruntwork-io/terraform-aws-influx/releases
+  source = "github.com/gruntwork-io/terraform-aws-influx//modules/kapacitor-iam-policies?ref=<VERSION>"
+
+  iam_role_id = "${module.kapacitor.iam_role_id}"
+}
+```
+
+Note the following parameters:
+
+* `source`: Use this parameter to specify the URL of this module. The double slash (`//`) is intentional 
+  and required. Terraform uses it to specify subfolders within a Git repo (see [module 
+  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in 
+  this repo. That way, instead of using the latest version of this module from the `master` branch, which 
+  will change every time you run Terraform, you're using a fixed version of the repo.
+
+* `iam_role_id`: Use this parameter to specify the ID of the IAM Role to which the policies in this module
+  should be added.
+
+
+You can find the other parameters in [variables.tf](variables.tf).
+
+Check out the [examples folder](https://github.com/gruntwork-io/terraform-aws-influx/blob/master/examples) for 
+working sample code.

--- a/modules/kapacitor-security-group-rules/README.md
+++ b/modules/kapacitor-security-group-rules/README.md
@@ -1,0 +1,58 @@
+# Kapacitor Server Security Group Rules Module
+
+This folder contains a [Terraform](https://www.terraform.io/) module that defines the Security Group rules used by a 
+[Kapacitor Enterprise](https://www.influxdata.com/time-series-platform/kapacitor/) cluster to control the traffic that is allowed to go in and out of the cluster. 
+These rules are defined in a separate module so that you can add them to any existing Security Group. 
+
+## Quick start
+
+Let's say you want to deploy Kapacitor using the [kapacitor-cluster 
+module](https://github.com/gruntwork-io/terraform-aws-influx/blob/master/modules/kapacitor-cluster): 
+
+```hcl
+module "kapacitor_cluster" {
+  # TODO: replace <VERSION> with the latest version from the releases page: https://github.com/gruntwork-io/terraform-aws-influx/releases
+  source = "github.com/gruntwork-io/terraform-aws-influx//modules/kapacitor-cluster?ref=<VERSION>"
+
+  # ... (other params omitted) ...
+}
+```
+
+You can attach the Security Group rules to this cluster as follows:
+
+```hcl
+module "security_group_rules" {
+  # TODO: replace <VERSION> with the latest version from the releases page: https://github.com/gruntwork-io/terraform-aws-influx/releases
+  source = "github.com/gruntwork-io/terraform-aws-influx//modules/kapacitor-security-group-rules?ref=<VERSION>"
+
+  security_group_id = "${module.kapacitor_cluster.security_group_id}"
+  
+  http_port                 = 8091
+  http_port_cidr_blocks     = ["0.0.0.0/0"]
+  http_port_security_groups = ["sg-abcd1234"]
+  
+  # ... (other params omitted) ...
+}
+```
+
+Note the following parameters:
+
+* `source`: Use this parameter to specify the URL of this module. The double slash (`//`) is intentional 
+  and required. Terraform uses it to specify subfolders within a Git repo (see [module 
+  sources](https://www.terraform.io/docs/modules/sources.html)). The `ref` parameter specifies a specific Git tag in 
+  this repo. That way, instead of using the latest version of this module from the `master` branch, which 
+  will change every time you run Terraform, you're using a fixed version of the repo.
+
+* `security_group_id`: Use this parameter to specify the ID of the security group to which the rules in this module
+  should be added.
+
+* `http_port`, `http_port_cidr_blocks`, `http_port_security_groups`: This shows an example of how to configure which 
+  ports you're using for various Kapacitor functionality, such as the RAFT consensus port, and which IP address ranges and 
+  Security Groups are allowed to connect to that port. Check out the [Clustering 
+  documentation](https://docs.influxdata.com/enterprise_kapacitor/v1.5/cluster-management/create-a-cluster/) to understand
+  what ports Kapacitor uses.
+  
+You can find the other parameters in [variables.tf](variables.tf).
+
+Check out the [examples folder](https://github.com/gruntwork-io/terraform-aws-influx/blob/master/examples) for 
+working sample code.

--- a/modules/run-kapacitor/README.md
+++ b/modules/run-kapacitor/README.md
@@ -1,0 +1,102 @@
+# Kapacitor Run Script
+
+This folder contains a script for configuring and initializing Kapacitor on an [AWS](https://aws.amazon.com/) server. 
+This script has been tested on the following operating systems:
+
+* Ubuntu 18.04
+* Amazon Linux 2
+
+There is a good chance it will work on other flavors of Debian, CentOS, and RHEL as well.
+
+## Quick start
+
+This script assumes you installed it, plus all of its dependencies (including Kapacitor itself), using the 
+[install-kapacitor module](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/modules/install-kapacitor). 
+
+This will:
+
+1. Fill out the templated configuration file with user supplied values.
+
+1. Start Kapacitor on the local node.
+
+1. Wait for all Kapacitor ASG to to spin up all desired instances then update `/etc/hosts` with the IPs of all instances.
+   the value of the instances' `Name` tag is used as the `hostname` entry.
+
+1. Figure out a rally point for your Kapacitor cluster. This is a "leader" Meta node that will be responsible for 
+   initializing the cluster. See [Picking a rally point](#picking-a-rally-point) for more info.
+
+1. On the rally point, initialize the cluster, including adding all nodes to the cluster
+
+We recommend using the `run-kapacitor` command as part of [User 
+Data](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html#user-data-shell-scripts), so that it executes
+when the EC2 Instance is first booting.
+
+See the [examples folder](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/examples) for 
+fully-working sample code.
+
+## Command line Arguments
+
+Run `run-kapacitor --help` to see all available arguments.
+
+```
+Usage: run-kapacitor [options]
+
+This script can be used to configure and initialize Kapacitor. This script has been tested with Ubuntu 18.04 and Amazon Linux 2.
+
+Options:
+
+  --hostname    The hostname of the current node.
+  --asg-name    The name of the ASG that contains meta nodes.
+  --region      The AWS region the Auto Scaling Groups are deployed in.
+  --auto-fill   Search the Kapacitor config file for KEY and replace it with VALUE. May be repeated.
+
+Example:
+
+  run-kapacitor --asg-name kapacitor-asg --region us-east-1 --auto-fill '<__LICENSE_KEY__>=******'
+```
+
+## Picking a rally point
+
+The Kapacitor cluster needs a "rally point", which is a single node that is responsible for:
+
+1. Initializing the cluster.
+1. Adding/removing nodes to the cluster.
+
+We need a way to unambiguously and reliably select exactly one rally point. If there's more than one node, you may end
+up with multiple separate clusters instead of just one!
+
+The `run-kapacitor` script can automatically pick a rally point automatically by:
+
+1. Looking up all the servers in the Auto Scaling Group specified via the `--asg-name` parameter.
+
+1. Pick the node with the oldest Launch Time as the rally point. If multiple nodes have identical launch times, use the
+   one with the earliest Instance ID, alphabetically.
+
+## Passing credentials securely
+
+The `run-kapacitor` script requires that you pass in your license key and shared secret. You should make sure to never 
+store these credentials in plaintext! You should use a secrets management tool to store the credentials in an encrypted
+format and only decrypt them, in memory, just before calling `run-kapacitor`. Here are some tools to consider:
+
+* [Vault](https://www.vaultproject.io/)
+* [Keywhiz](https://square.github.io/keywhiz/)
+* [KMS](https://aws.amazon.com/kms/)
+
+Moreover, if you're ever calling `run-kapacitor` interactively (i.e., you're manually running CLI commands
+rather than executing a script), be careful of passing credentials directly on the command line, or they will be 
+stored, in plaintext, [in Bash 
+history](https://www.digitalocean.com/community/tutorials/how-to-use-bash-history-commands-and-expansions-on-a-linux-vps)!
+You can either use a CLI tool to set the credentials as environment variables or you can [temporarily disable Bash
+history](https://linuxconfig.org/how-to-disable-bash-shell-commands-history-on-linux). 
+
+## Required permissions
+
+The `run-kapacitor` script assumes it is running on an EC2 Instance with an [IAM 
+Role](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) that has the following permissions:
+
+* `ec2:DescribeInstances`
+* `ec2:DescribeTags`
+* `autoscaling:DescribeAutoScalingGroups`
+
+These permissions are automatically added by the [kapacitor-cluster 
+module](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/modules/kapacitor-cluster).


### PR DESCRIPTION
This PR adds READMEs for the following soon to be built modules:

* `install-kapacitor`: Bash script for installing Kapacitor Enterprise on a node
* `run-kapacitor`: Bash script for configuring and starting Kapacitor Enterprise on a node
* `kapacitor-cluster`: Terraform module for deploying a Kapacitor Enterprise cluster
* `kapacitor-iam-policies`: Terraform module for specifying IAM policies to be attached to each node in a Kapacitor Enterprise cluster
* `kapacitor-security-group-rules`: Terraform module for specifying security group rules to be attached to each node in a Kapacitor Enterprise cluster