### PR TITLE
Chronograf Run Module

### DIFF
--- a/examples/tick-ami/tick.json
+++ b/examples/tick-ami/tick.json
@@ -4,7 +4,8 @@
     "aws_region": "us-east-1",
     "base_ami_name": "tick",
     "telegraf_version": "1.9.4",
-    "influxdb_version": "1.6.2"
+    "influxdb_version": "1.6.2",
+    "chronograf_version": "1.7.8"
   },
   "builders": [{
     "name": "tick-ami-ubuntu",
@@ -108,13 +109,18 @@
     "destination": "/tmp/config/influxdb.conf"
   },{
     "type": "file",
+    "source": "{{template_dir}}/../chronograf-ami/config/chronograf",
+    "destination": "/tmp/config/chronograf"
+  },{
+    "type": "file",
     "source": "{{template_dir}}/../../modules/",
     "destination": "/tmp/terraform-aws-influx/modules"
   },{
     "type": "shell",
     "inline": [
       "/tmp/terraform-aws-influx/modules/install-telegraf/install-telegraf --version {{user `telegraf_version`}}",
-      "/tmp/terraform-aws-influx/modules/install-influxdb/install-influxdb --version {{user `influxdb_version`}}"
+      "/tmp/terraform-aws-influx/modules/install-influxdb/install-influxdb --version {{user `influxdb_version`}}",
+      "/tmp/terraform-aws-influx/modules/install-chronograf/install-chronograf --version {{user `chronograf_version`}}"
     ]
   }],
   "post-processors": [{

--- a/examples/tick-multi-cluster/local-test/docker-compose.yml
+++ b/examples/tick-multi-cluster/local-test/docker-compose.yml
@@ -63,7 +63,7 @@ services:
   telegraf-0:
     image: gruntwork/telegraf-${OS_NAME}
     entrypoint: ["/entrypoint/entrypoint.sh"]
-    container_name: telegraf-meta-0
+    container_name: telegraf-0
 
     # Required to make systemd happy
     privileged: true
@@ -88,3 +88,36 @@ services:
       # the User Data script, with the USER_DATA_ENV_ portion stripped off.
       USER_DATA_ENV_influxdb_url: http://influxdb-data-0:8086
       USER_DATA_ENV_database_name: telegraf
+
+  chronograf-0:
+    image: gruntwork/chronograf-${OS_NAME}
+    entrypoint: ["/entrypoint/entrypoint.sh"]
+    container_name: chronograf-0
+
+    # Required to make systemd happy
+    privileged: true
+
+    volumes:
+      # Used for systemd
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+
+      # Mount these scripts so we get hot reload
+      - ../../../modules/run-chronograf/run-chronograf:/opt/chronograf/bin/run-chronograf
+
+      # Mount the scripts we use to run Telegraf during Docker container boot
+      - ../user-data:/user-data
+      - ../../local-mocks/entrypoint.sh:/entrypoint/entrypoint.sh
+
+    container_name: chronograf-0
+    environment:
+      # The User Data script that will be executed on boot by entrypoint.sh
+      USER_DATA_SCRIPT: /user-data/chronograf/user-data.sh
+
+      # Any environment variable starting with USER_DATA_ENV_ will be read in by entrypoint.sh and made available in
+      # the User Data script, with the USER_DATA_ENV_ portion stripped off.
+      USER_DATA_ENV_host: 0.0.0.0
+      USER_DATA_ENV_port: 8888
+
+    ports:
+      # Map these ports to any available port number on the host
+      - "8888:8888"

--- a/examples/tick-multi-cluster/user-data/chronograf/user-data.sh
+++ b/examples/tick-multi-cluster/user-data/chronograf/user-data.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Send the log output from this script to user-data.log, syslog, and the console
+# From: https://alestic.com/2010/12/ec2-user-data-output/
+exec > >(tee /user-data/mock-user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
+
+function run_chronograf {
+  local -r host="$1"
+  local -r port="$2"
+
+  "/opt/chronograf/bin/run-chronograf" \
+    --auto-fill "<__HOST__>=$host" \
+    --auto-fill "<__PORT__>=$port"
+}
+
+run_chronograf \
+  "${host}" \
+  "${port}"

--- a/examples/tick-single-cluster/local-test/docker-compose.yml
+++ b/examples/tick-single-cluster/local-test/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       # Mount these scripts so we get hot reload
       - ../../../modules/run-telegraf/run-telegraf:/opt/telegraf/bin/run-telegraf
       - ../../../modules/run-influxdb/run-influxdb:/opt/influxdb/bin/run-influxdb
+      - ../../../modules/run-chronograf/run-chronograf:/opt/chronograf/bin/run-chronograf
       - ../../../modules/influxdb-commons:/opt/influxdb-commons
 
       # Override scripts with mocks so we can run locally, without talking to AWS APIs
@@ -46,7 +47,10 @@ services:
       USER_DATA_ENV_volume_owner: influxdb
       USER_DATA_ENV_influxdb_url: http://localhost:8086
       USER_DATA_ENV_database_name: telegraf
+      USER_DATA_ENV_host: 0.0.0.0
+      USER_DATA_ENV_port: 8888
     
     ports:
       # Map these ports to any available port number on the host
       - "8086:8086"
+      - "8888:8888"

--- a/examples/tick-single-cluster/user-data/user-data.sh
+++ b/examples/tick-single-cluster/user-data/user-data.sh
@@ -70,6 +70,15 @@ function run_telegraf {
     --auto-fill "<__DATABASE_NAME__>=$database_name"
 }
 
+function run_chronograf {
+  local -r host="$1"
+  local -r port="$2"
+
+  "/opt/chronograf/bin/run-chronograf" \
+    --auto-fill "<__HOST__>=$host" \
+    --auto-fill "<__PORT__>=$port"
+}
+
 run_influxdb \
   "${cluster_asg_name}" \
   "${aws_region}" \
@@ -82,3 +91,7 @@ run_influxdb \
 run_telegraf \
   "${influxdb_url}" \
   "${database_name}"
+
+run_chronograf \
+  "${host}" \
+  "${port}"

--- a/modules/install-chronograf/install-chronograf
+++ b/modules/install-chronograf/install-chronograf
@@ -54,6 +54,17 @@ function install_chronograf_on_amazon_linux {
   sudo yum localinstall -y "chronograf-${version}.x86_64.rpm"
 }
 
+function install_chronograf_scripts {
+  local -r dest_dir="$1"
+
+  local -r run_chronograf_src="$SCRIPT_DIR/../run-chronograf/run-chronograf"
+  local -r run_chronograf_dest="$dest_dir/run-chronograf"
+
+  log_info "Copying $run_chronograf_src to $run_chronograf_dest"
+  sudo mkdir -p "$dest_dir"
+  sudo cp "$run_chronograf_src" "$run_chronograf_dest"
+}
+
 function install_chronograf {
   local version="$DEFAULT_CHRONOGRAF_VERSION"
   local config_file="$DEFAULT_TEMP_CHRONOGRAF_CONFIG_FILE_PATH"
@@ -103,6 +114,7 @@ function install_chronograf {
   sudo systemctl disable chronograf.service
 
   sudo mv "$config_file" "$DEFAULT_CHRONOGRAF_CONFIG_FILE_PATH"
+  install_chronograf_scripts "$DEFAULT_CHRONOGRAF_BIN_DIR"
 }
 
 install_chronograf "$@"

--- a/modules/run-chronograf/run-chronograf
+++ b/modules/run-chronograf/run-chronograf
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Import the appropriate bash commons libraries
+readonly BASH_COMMONS_DIR="/opt/gruntwork/bash-commons"
+readonly DEFAULT_CHRONOGRAF_CONFIG_FILE_PATH="/etc/default/chronograf"
+
+if [[ ! -d "$BASH_COMMONS_DIR" ]]; then
+  echo "ERROR: this script requires that bash-commons is installed in $BASH_COMMONS_DIR. See https://github.com/gruntwork-io/bash-commons for more info."
+  exit 1
+fi
+
+source "$BASH_COMMONS_DIR/assert.sh"
+source "$BASH_COMMONS_DIR/file.sh"
+source "$BASH_COMMONS_DIR/log.sh"
+
+function print_usage {
+  echo
+  echo "Usage: run-chronograf [options]"
+  echo
+  echo "This script can be used to configure and initialize Chronograf. This script has been tested with Ubuntu 18.04 and Amazon Linux 2."
+  echo
+  echo "Options:"
+  echo
+  echo -e "  --auto-fill\tSearch the Chronograf config file for KEY and replace it with VALUE. May be repeated."
+
+  echo
+  echo "Example:"
+  echo
+  echo "  run-chronograf --auto-fill '<__HOST__>0.0.0.0' --auto-fill '<__PORT__>=8888'"
+}
+
+function run_chronograf {
+  local -a auto_fill=()
+
+  while [[ $# > 0 ]]; do
+    local key="$1"
+    case "$key" in
+      --auto-fill)
+        assert_not_empty "$key" "$2"
+        auto_fill+=("$2")
+        shift
+        ;;
+      *)
+        echo "Unrecognized argument: $key"
+        print_usage
+        exit 1
+        ;;
+    esac
+
+    shift
+  done
+
+  file_fill_template "$DEFAULT_CHRONOGRAF_CONFIG_FILE_PATH" "${auto_fill[@]}"
+
+  log_info "Starting Chronograf"
+  sudo systemctl enable chronograf.service
+  sudo systemctl start chronograf.service
+}
+
+run_chronograf "$@"


### PR DESCRIPTION
This PR does the following:

* Include `run-chronograf` script to update the config and start up the Chronograf service
* Update `install-chronograf` script to install `run-chronograf` script in `/opt/chronograf/bin`
* Update `install-chronograf` script to disable Chronograf service so it doesn't start up on first instance boot
* Adds Chronograf to Packer template that includes the entire TICK stack*
* Adds Chronograf to local docker example, `tick-single-cluster`
* Add Chronograf local docker example, `tick-multi-cluster`

![screenshot 2019-02-25 at 4 36 19 pm](https://user-images.githubusercontent.com/7319262/53351002-af0b4980-3920-11e9-9cf9-82bb66848d68.png)
