### PR TITLE
Chronograf Server

### DIFF
--- a/modules/chronograf-security-group-rules/main.tf
+++ b/modules/chronograf-security-group-rules/main.tf
@@ -3,7 +3,7 @@
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "aws_security_group_rule" "http_port_cidr_blocks" {
-  count             = "${signum(length(var.http_port_cidr_blocks))}"
+  count             = "${length(var.http_port_cidr_blocks) >= 1 ? 1 : 0}"
   type              = "ingress"
   from_port         = "${var.http_port}"
   to_port           = "${var.http_port}"

--- a/modules/chronograf-security-group-rules/main.tf
+++ b/modules/chronograf-security-group-rules/main.tf
@@ -1,0 +1,23 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# ATTACH SECURITY GROUP RULE TO ALLOW INCOMING CONNECTIONS ON CHRONGRAF'S LISTENING PORT
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_security_group_rule" "http_port_cidr_blocks" {
+  count             = "${signum(length(var.http_port_cidr_blocks))}"
+  type              = "ingress"
+  from_port         = "${var.http_port}"
+  to_port           = "${var.http_port}"
+  protocol          = "tcp"
+  security_group_id = "${var.security_group_id}"
+  cidr_blocks       = ["${var.http_port_cidr_blocks}"]
+}
+
+resource "aws_security_group_rule" "http_port_security_groups" {
+  count                    = "${var.http_port_security_groups_num}"
+  type                     = "ingress"
+  from_port                = "${var.http_port}"
+  to_port                  = "${var.http_port}"
+  protocol                 = "tcp"
+  security_group_id        = "${var.security_group_id}"
+  source_security_group_id = "${element(var.http_port_security_groups, count.index)}"
+}

--- a/modules/chronograf-security-group-rules/outputs.tf
+++ b/modules/chronograf-security-group-rules/outputs.tf
@@ -1,0 +1,3 @@
+output "http_port" {
+  value = "${var.http_port}"
+}

--- a/modules/chronograf-security-group-rules/variables.tf
+++ b/modules/chronograf-security-group-rules/variables.tf
@@ -1,0 +1,34 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# REQUIRED PARAMETERS
+# You must provide a value for each of these parameters.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "security_group_id" {
+  description = "The ID of the Security Group to which all the rules should be attached."
+}
+
+variable "http_port" {
+  description = "The HTTP port that Chronograf will listen on for connections"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+# These parameters have reasonable defaults.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "http_port_cidr_blocks" {
+  description = "The list of IP address ranges in CIDR notation from which to allow connections to the http_port."
+  type        = "list"
+  default     = []
+}
+
+variable "http_port_security_groups" {
+  description = "The list of Security Group IDs from which to allow connections to the http_port. If you update this variable, make sure to update var.http_port_security_groups_num too!"
+  type        = "list"
+  default     = []
+}
+
+variable "http_port_security_groups_num" {
+  description = "The number of security group IDs in var.http_port_security_groups. We should be able to compute this automatically, but due to a Terraform limitation, if there are any dynamic resources in var.http_port_security_groups, then we won't be able to: https://github.com/hashicorp/terraform/pull/11482"
+  default     = 0
+}

--- a/modules/chronograf-server/README.md
+++ b/modules/chronograf-server/README.md
@@ -55,7 +55,7 @@ fully-working sample code.
 
 ## How do you connect to the Chronograf server?
 
-Once deployed you an simply access the web UI by visiting the http://<public-ip>:<port>, you can get the `public_ip` by running:
+Once deployed you can simply access the web UI by visiting the http://<public-ip>:<port>, you can get the `public_ip` by running:
 
 ```bash
 $ terraform output public_ip

--- a/modules/chronograf-server/README.md
+++ b/modules/chronograf-server/README.md
@@ -55,13 +55,16 @@ fully-working sample code.
 
 ## How do you connect to the Chronograf server?
 
-Once deployed you an simply access the web UI by visiting the public IP of the server on the specified port.
+Once deployed you an simply access the web UI by visiting the http://<public-ip>:<port>, you can get the `public_ip` by running:
+
+```bash
+$ terraform output public_ip
+```
 
 ## What's included in this module?
 
 This module creates the following:
 
-* [Auto Scaling Group](#auto-scaling-group)
 * [Security Group](#security-group)
 
 ### Security Group

--- a/modules/chronograf-server/main.tf
+++ b/modules/chronograf-server/main.tf
@@ -1,0 +1,59 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# CREATE AN EC2 INSTANCE TO RUN CHRONOGRAF
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_instance" "chronograf_server" {
+  ami                    = "${var.ami_id}"
+  instance_type          = "${var.instance_type}"
+  user_data              = "${var.user_data}"
+  key_name               = "${var.ssh_key_name}"
+  vpc_security_group_ids = ["${aws_security_group.chronograf_security_group.id}"]
+  tags                   = "${var.tags}"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CREATE A SECURITY GROUP TO CONTROL WHAT REQUESTS CAN GO IN AND OUT OF THE EC2 INSTANCE
+# We export the ID of the security group as an output variable so users can attach custom rules.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_security_group" "chronograf_security_group" {
+  name_prefix = "chronograf"
+  description = "Security group for the Chronograf server"
+  vpc_id      = "${var.vpc_id}"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# ATTACH DEFAULT SECURITY GROUP RULES TO ALLOW SSH ACCESS AND ALL OUTBOUND CONNECTIONS
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_security_group_rule" "allow_ssh_inbound" {
+  count       = "${length(var.allowed_ssh_cidr_blocks) >= 1 ? 1 : 0}"
+  type        = "ingress"
+  from_port   = "${var.ssh_port}"
+  to_port     = "${var.ssh_port}"
+  protocol    = "tcp"
+  cidr_blocks = ["${var.allowed_ssh_cidr_blocks}"]
+
+  security_group_id = "${aws_security_group.chronograf_security_group.id}"
+}
+
+resource "aws_security_group_rule" "allow_ssh_inbound_from_security_group_ids" {
+  count                    = "${var.allowed_ssh_security_group_ids_num}"
+  type                     = "ingress"
+  from_port                = "${var.ssh_port}"
+  to_port                  = "${var.ssh_port}"
+  protocol                 = "tcp"
+  source_security_group_id = "${element(var.allowed_ssh_security_group_ids, count.index)}"
+
+  security_group_id = "${aws_security_group.chronograf_security_group.id}"
+}
+
+resource "aws_security_group_rule" "allow_all_outbound" {
+  type        = "egress"
+  from_port   = 0
+  to_port     = 0
+  protocol    = "-1"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.chronograf_security_group.id}"
+}

--- a/modules/chronograf-server/main.tf
+++ b/modules/chronograf-server/main.tf
@@ -8,7 +8,7 @@ resource "aws_instance" "chronograf_server" {
   user_data              = "${var.user_data}"
   key_name               = "${var.ssh_key_name}"
   vpc_security_group_ids = ["${aws_security_group.chronograf_security_group.id}"]
-  tags                   = "${var.tags}"
+  tags                   = "${merge(map("Name", "${var.server_name}"), var.tags)}"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -17,7 +17,7 @@ resource "aws_instance" "chronograf_server" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "aws_security_group" "chronograf_security_group" {
-  name_prefix = "chronograf"
+  name_prefix = "${var.server_name}-"
   description = "Security group for the Chronograf server"
   vpc_id      = "${var.vpc_id}"
 }

--- a/modules/chronograf-server/outputs.tf
+++ b/modules/chronograf-server/outputs.tf
@@ -1,0 +1,7 @@
+output "public_ip" {
+  value = "${aws_instance.chronograf_server.public_ip}"
+}
+
+output "security_group_id" {
+  value = "${aws_security_group.chronograf_security_group.id}"
+}

--- a/modules/chronograf-server/variables.tf
+++ b/modules/chronograf-server/variables.tf
@@ -1,0 +1,58 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# REQUIRED PARAMETERS
+# You must provide a value for each of these parameters.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "ami_id" {
+  description = "The ID of the AMI to run in this cluster."
+}
+
+variable "instance_type" {
+  description = "The type of EC2 Instances to run for each node in the cluster (e.g. t2.micro)."
+}
+
+variable "vpc_id" {
+  description = "The ID of the VPC in which to deploy the InfluxDB cluster"
+}
+
+variable "user_data" {
+  description = "A User Data script to execute while the server is booting."
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+# These parameters have reasonable defaults.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "ssh_key_name" {
+  description = "The name of an EC2 Key Pair that can be used to SSH to the EC2 Instance. Set to an empty string to not associate a Key Pair."
+  default     = ""
+}
+
+variable "allowed_ssh_cidr_blocks" {
+  description = "A list of CIDR-formatted IP address ranges from which the EC2 Instance will allow SSH connections"
+  type        = "list"
+  default     = []
+}
+
+variable "allowed_ssh_security_group_ids" {
+  description = "A list of security group IDs from which the EC2 Instance will allow SSH connections"
+  type        = "list"
+  default     = []
+}
+
+variable "allowed_ssh_security_group_ids_num" {
+  description = "The number of security group IDs in var.allowed_ssh_security_group_ids. We should be able to compute this automatically, but due to a Terraform limitation, if there are any dynamic resources in var.allowed_ssh_security_group_ids, then we won't be able to: https://github.com/hashicorp/terraform/pull/11482"
+  default     = 0
+}
+
+variable "ssh_port" {
+  description = "The port used for SSH connections"
+  default     = 22
+}
+
+variable "tags" {
+  description = "Tags to attach to the EC2 Instance."
+  type        = "map"
+  default     = {}
+}

--- a/modules/chronograf-server/variables.tf
+++ b/modules/chronograf-server/variables.tf
@@ -3,6 +3,10 @@
 # You must provide a value for each of these parameters.
 # ---------------------------------------------------------------------------------------------------------------------
 
+variable "server_name" {
+  description = "The name of the Chronograf server. This variable is used to namespace all resources created by this module."
+}
+
 variable "ami_id" {
   description = "The ID of the AMI to run in this cluster."
 }


### PR DESCRIPTION
This PR does the following:

* Add the `chronograf-server` Terraform module that deploys an EC2 instance with Chronograf running
* Add the `chronograf-security-group-rules` Terraform module to allow opening up inbound requests on the HTTP port the server (deployed by the module above) listens on for requests