### PR TITLE
[Examples and Tests] Tick Single Cluster

### DIFF
--- a/examples/tick-single-cluster/README.md
+++ b/examples/tick-single-cluster/README.md
@@ -14,7 +14,7 @@ example](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/exampl
 To see an example of TICK deployed across separate clusters, see the [tick-multi-cluster
 example](https://github.com/gruntwork-io/terraform-aws-influx/blob/master/examples/tick-multi-cluster).
 
-## What resources are does this example deploy?
+## What resources does this example deploy?
 
 1. A single _all in one server_ behind an ASG where we run 
     [telegraf](/modules/run-telegraf), [influxdb](/modules/run-influxdb),

--- a/examples/tick-single-cluster/README.md
+++ b/examples/tick-single-cluster/README.md
@@ -1,0 +1,56 @@
+# TICK Single Cluster Example
+
+This folder shows an example of Terraform code that uses the
+[tick-cluster](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/modules/tick-cluster) 
+module to deploy a [TICK stack](https://www.influxdata.com/time-series-platform/) cluster in [AWS](https://aws.amazon.com/).
+
+This example also deploys a Load Balancer in front of the TICK cluster using the [load-balancer
+module](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/modules/load-balancer).
+
+You will need to create an [Amazon Machine Image (AMI)](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) 
+that has all components of the TICK stack installed, which you can do using the [tick-ami 
+example](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/examples/tick-ami)). 
+
+To see an example of TICK deployed across separate clusters, see the [tick-multi-cluster
+example](https://github.com/gruntwork-io/terraform-aws-influx/blob/master/examples/tick-multi-cluster).
+
+## What resources are does this example deploy?
+
+1. A single _all in one server_ behind an ASG where we run 
+    [telegraf](/modules/run-telegraf), [influxdb](/modules/run-influxdb),
+    [chronograf](/modules/run-chronograf) and [kapacitor](/modules/run-kapacitor)
+1. An [Application Load Balancer](https://github.com/gruntwork-io/module-load-balancer)
+
+You will need to create [Amazon Machine Images (AMIs)](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) 
+that have all of the ELK components installed. You can do this using: 
+- [TICK all-in-one AMI example](/examples/tick-ami)
+
+## Quick start
+
+To deploy a TICK Cluster:
+
+1. `git clone` this repo to your computer.
+1. Optional: build a custom TICK AMI. See the
+   [tick-ami example](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/examples/tick-ami)
+   documentation for instructions. Make sure to note down the ID of the AMI.
+1. Install [Terraform](https://www.terraform.io/).
+1. Open the `variables.tf` file in this folder, set the environment variables specified at the top of the
+   file, and fill in any other variables that don't have a default. If you built a custom AMI, put its ID into the
+   `ami_id` variable. If you didn't, this example will use public AMIs that Gruntwork has published, which are fine for
+   testing/learning, but not recommended for production use.
+1. Run `terraform init`
+1. Run `terraform apply`
+
+## Connecting to the cluster
+
+### InfluxDB
+
+Check out [How do you connect to the InfluxDB 
+cluster](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/modules/influxdb-cluster#how-do-you-connect-to-the-influxdb-cluster)
+documentation.
+
+### Chronograf
+
+Check out [How do you connect to the Chronograf 
+cluster](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/modules/chronograf-server#how-do-you-connect-to-the-chronograf-server)
+documentation.

--- a/examples/tick-single-cluster/README.md
+++ b/examples/tick-single-cluster/README.md
@@ -22,7 +22,7 @@ example](https://github.com/gruntwork-io/terraform-aws-influx/blob/master/exampl
 1. An [Application Load Balancer](https://github.com/gruntwork-io/module-load-balancer)
 
 You will need to create [Amazon Machine Images (AMIs)](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) 
-that have all of the ELK components installed. You can do this using: 
+that have all of the TICK-stack components installed. You can do this using: 
 - [TICK all-in-one AMI example](/examples/tick-ami)
 
 ## Quick start

--- a/examples/tick-single-cluster/main.tf
+++ b/examples/tick-single-cluster/main.tf
@@ -1,0 +1,221 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPLOY A SINGLE NODE TICK CLUSTER
+# ---------------------------------------------------------------------------------------------------------------------
+
+provider "aws" {
+  # The AWS region in which all resources will be created
+  region = "${var.aws_region}"
+}
+
+module "tick" {
+  # When using these modules in your own code, you will need to use a Git URL with a ref attribute that pins you
+  # to a specific version of the modules, such as the following example:
+  # source = "git::git@github.com:gruntwork-io/terraform-aws-influx.git//modules/influxdb-cluster?ref=v0.0.1"
+  source = "../../modules/influxdb-cluster"
+
+  cluster_name = "${var.cluster_name}"
+  min_size     = 1
+  max_size     = 1
+
+  # We use small instance types to keep these examples cheap to run. In a production setting, you'll probably want
+  # R4 or M4 instances.
+  instance_type = "t2.micro"
+
+  ami_id    = "${var.ami_id}"
+  user_data = "${data.template_file.user_data_tick.rendered}"
+
+  vpc_id     = "${data.aws_vpc.default.id}"
+  subnet_ids = "${data.aws_subnet_ids.default.ids}"
+
+  ebs_block_devices = [
+    {
+      device_name = "${var.volume_device_name}"
+      volume_type = "gp2"
+      volume_size = 50
+    },
+  ]
+
+  # To make testing easier, we allow SSH requests from any IP address here. In a production deployment, we strongly
+  # recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.
+  allowed_ssh_cidr_blocks = ["0.0.0.0/0"]
+
+  ssh_key_name = "${var.ssh_key_name}"
+
+  # To make it easy to test this example from your computer, we allow the InfluxDB servers to have public IPs. In a
+  # production deployment, you'll probably want to keep all the servers in private subnets with only private IPs.
+  associate_public_ip_address = true
+
+  # An example of custom tags
+  tags = [
+    {
+      key                 = "Environment"
+      value               = "development"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "NodeType"
+      value               = "both"
+      propagate_at_launch = true
+    },
+  ]
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CREATE USER DATA SCRIPTS THAT WILL RUN ON EACH INSTANCE IN THE VARIOUS CLUSTERS ON BOOT
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "template_file" "user_data_tick" {
+  template = "${file("${path.module}/user-data/user-data.sh")}"
+
+  vars {
+    # InfluxDB
+    cluster_asg_name = "${var.cluster_name}"
+    aws_region       = "${var.aws_region}"
+    license_key      = "${var.license_key}"
+    shared_secret    = "${var.shared_secret}"
+
+    # Pass in the data about the EBS volumes so they can be mounted
+    volume_device_name = "${var.volume_device_name}"
+    volume_mount_point = "${var.volume_mount_point}"
+    volume_owner       = "${var.volume_owner}"
+
+    # Telegraf
+    influxdb_url  = "http://localhost:8086"
+    database_name = "${var.telegraf_database}"
+
+    # Chronograf
+    host = "0.0.0.0"
+    port = "8888"
+  }
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CONFIGURE THE SECURITY GROUP RULES FOR INFLUXDB
+# This controls which ports are exposed and who can connect to them
+# ---------------------------------------------------------------------------------------------------------------------
+
+module "influxdb_security_group_rules" {
+  # When using these modules in your own code, you will need to use a Git URL with a ref attribute that pins you
+  # to a specific version of the modules, such as the following example:
+  # source = "git::git@github.com:gruntwork-io/terraform-aws-influx.git//modules/influxdb-security-group-rules?ref=v0.0.1"
+  source = "../../modules/influxdb-security-group-rules"
+
+  security_group_id = "${module.tick.security_group_id}"
+
+  raft_port = 8089
+  rest_port = 8091
+  tcp_port  = 8088
+  api_port  = 8086
+
+  # To keep this example simple, we allow these ports to be accessed from any IP. In a production
+  # deployment, you may want to lock these down just to trusted servers.
+  raft_port_cidr_blocks = ["0.0.0.0/0"]
+
+  rest_port_cidr_blocks = ["0.0.0.0/0"]
+  tcp_port_cidr_blocks  = ["0.0.0.0/0"]
+  api_port_cidr_blocks  = ["0.0.0.0/0"]
+}
+
+module "chronograf_security_group_rules" {
+  # When using these modules in your own code, you will need to use a Git URL with a ref attribute that pins you
+  # to a specific version of the modules, such as the following example:
+  # source = "git::git@github.com:gruntwork-io/terraform-aws-influx.git//modules/chronograf-security-group-rules?ref=v0.0.1"
+  source = "../../modules/chronograf-security-group-rules"
+
+  security_group_id = "${module.tick.security_group_id}"
+
+  http_port = 8888
+
+  # To keep this example simple, we allow these ports to be accessed from any IP. In a production
+  # deployment, you may want to lock these down just to trusted servers.
+  http_port_cidr_blocks = ["0.0.0.0/0"]
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# ATTACH IAM POLICIES TO EACH CLUSTER
+# These policies allow the clusters to automatically bootstrap themselves
+# ---------------------------------------------------------------------------------------------------------------------
+
+module "influxdb_iam_policies" {
+  # When using these modules in your own code, you will need to use a Git URL with a ref attribute that pins you
+  # to a specific version of the modules, such as the following example:
+  # source = "git::git@github.com:gruntwork-io/terraform-aws-influx.git//modules/influxdb-iam-policies?ref=v0.0.1"
+  source = "../../modules/influxdb-iam-policies"
+
+  iam_role_id = "${module.tick.iam_role_id}"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPLOY A LOAD BALANCER FOR THE CLUSTERS
+# ---------------------------------------------------------------------------------------------------------------------
+
+module "load_balancer" {
+  # When using these modules in your own code, you will need to use a Git URL with a ref attribute that pins you
+  # to a specific version of the modules, such as the following example:
+  # source = "git::git@github.com:gruntwork-io/terraform-aws-influx.git//modules/load-balancer?ref=v0.0.1"
+  source = "../../modules/load-balancer"
+
+  name       = "${var.cluster_name}-lb"
+  vpc_id     = "${data.aws_vpc.default.id}"
+  subnet_ids = "${data.aws_subnet_ids.default.ids}"
+
+  http_listener_ports = [8086, 8888]
+
+  # To make testing easier, we allow inbound connections from any IP. In production usage, you may want to only allow
+  # connectsion from certain trusted servers, or even use an internal load balancer, so it's only accessible from
+  # within the VPC
+
+  allow_inbound_from_cidr_blocks = ["0.0.0.0/0"]
+  idle_timeout                   = 3600
+}
+
+module "influxdb_target_group" {
+  # When using these modules in your own code, you will need to use a Git URL with a ref attribute that pins you
+  # to a specific version of the modules, such as the following example:
+  # source = "git::git@github.com:gruntwork-io/terraform-aws-influx.git//modules/load-balancer-target-group?ref=v0.0.1"
+  source = "../../modules/load-balancer-target-group"
+
+  target_group_name    = "${var.cluster_name}-itg"
+  asg_name             = "${module.tick.asg_name}"
+  port                 = "${module.influxdb_security_group_rules.api_port}"
+  health_check_path    = "/ping"
+  health_check_matcher = "204"
+  vpc_id               = "${data.aws_vpc.default.id}"
+
+  listener_arns                   = ["${lookup(module.load_balancer.http_listener_arns, 8086)}"]
+  listener_arns_num               = 1
+  listener_rule_starting_priority = 100
+}
+
+module "chronograf_target_group" {
+  # When using these modules in your own code, you will need to use a Git URL with a ref attribute that pins you
+  # to a specific version of the modules, such as the following example:
+  # source = "git::git@github.com:gruntwork-io/terraform-aws-influx.git//modules/load-balancer-target-group?ref=v0.0.1"
+  source = "../../modules/load-balancer-target-group"
+
+  target_group_name    = "${var.cluster_name}-ctg"
+  asg_name             = "${module.tick.asg_name}"
+  port                 = "${module.chronograf_security_group_rules.http_port}"
+  health_check_path    = "/"
+  health_check_matcher = "200"
+  vpc_id               = "${data.aws_vpc.default.id}"
+
+  listener_arns                   = ["${lookup(module.load_balancer.http_listener_arns, 8888)}"]
+  listener_arns_num               = 1
+  listener_rule_starting_priority = 100
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# DEPLOY INFLUXDB IN THE DEFAULT VPC AND SUBNETS
+# Using the default VPC and subnets makes this example easy to run and test, but it means InfluxDB is accessible from
+# the public Internet. For a production deployment, we strongly recommend deploying into a custom VPC with private
+# subnets.
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnet_ids" "default" {
+  vpc_id = "${data.aws_vpc.default.id}"
+}

--- a/examples/tick-single-cluster/outputs.tf
+++ b/examples/tick-single-cluster/outputs.tf
@@ -1,0 +1,16 @@
+
+output "cluster_asg_name" {
+  value = "${module.tick.asg_name}"
+}
+
+output "lb_dns_name" {
+  value = "${module.load_balancer.alb_dns_name}"
+}
+
+output "influxdb_port" {
+  value = "${module.influxdb_security_group_rules.api_port}"
+}
+
+output "chronograf_port" {
+  value = "${module.chronograf_security_group_rules.http_port}"
+}

--- a/examples/tick-single-cluster/variables.tf
+++ b/examples/tick-single-cluster/variables.tf
@@ -1,0 +1,66 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# ENVIRONMENT VARIABLES
+# Define these secrets as environment variables
+# ---------------------------------------------------------------------------------------------------------------------
+
+# AWS_ACCESS_KEY_ID
+# AWS_SECRET_ACCESS_KEY
+
+# ---------------------------------------------------------------------------------------------------------------------
+# REQUIRED PARAMETERS
+# You must provide a value for each of these parameters.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "license_key" {
+  description = "The key of your InfluxDB Enterprise license. This should not be set in plain-text and can be passed in as an env var or from a secrets management tool."
+}
+
+variable "shared_secret" {
+  description = "A long pass phrase that will be used to sign tokens for intra-cluster communication on data nodes. This should not be set in plain-text and can be passed in as an env var or from a secrets management tool."
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+# These parameters have reasonable defaults.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "aws_region" {
+  description = "The AWS region in which all resources will be created"
+  default     = "us-east-1"
+}
+
+variable "ami_id" {
+  description = "The ID of the AMI to run in the cluster. This should be an AMI built from the Packer template under examples/influxdb-ami/influxdb.json."
+  default     = ""
+}
+
+variable "cluster_name" {
+  description = "What to name the InfluxDB meta nodes cluster and all of its associated resources"
+  default     = "tick-cluster"
+}
+
+variable "telegraf_database" {
+  description = "The name of the InfluxDB database Telegraf writes metrics to"
+  default     = "telegraf"
+}
+
+variable "ssh_key_name" {
+  description = "The name of an EC2 Key Pair that can be used to SSH to the EC2 Instances in this cluster. Set to an empty string to not associate a Key Pair."
+  default     = ""
+}
+
+variable "volume_device_name" {
+  description = "The device name to use for the EBS Volume used for the meta, data, wal and hh directories on InfluxDB nodes."
+  default     = "/dev/xvdh"
+}
+
+variable "volume_mount_point" {
+  description = "The mount point (folder path) to use for the EBS Volume used for the meta, data, wal and hh directories on InfluxDB data nodes."
+  default     = "/influxdb"
+}
+
+variable "volume_owner" {
+  description = "The OS user who should be made the owner of mount points."
+  default     = "influxdb"
+}
+

--- a/test/tick_single_cluster_test.go
+++ b/test/tick_single_cluster_test.go
@@ -1,0 +1,132 @@
+package test
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/aws"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTickSingleCluster(t *testing.T) {
+	t.Parallel()
+
+	// For convenience - uncomment these as well as the "os" import
+	// when doing local testing if you need to skip any sections.
+	// os.Setenv("SKIP_", "true")
+	// os.Setenv("TERRATEST_REGION", "us-east-1")
+	// os.Setenv("SKIP_setup_ami", "true")
+	// os.Setenv("SKIP_deploy_to_aws", "true")
+	// os.Setenv("SKIP_validate_influxdb", "true")
+	// os.Setenv("SKIP_validate_telegraf", "true")
+	// os.Setenv("SKIP_validate_chronograf", "true")
+	// os.Setenv("SKIP_teardown", "true")
+
+	var testcases = []struct {
+		testName      string
+		packerInfo    PackerInfo
+		sleepDuration int
+	}{
+		{
+			"TestTickSingleClusterUbuntu",
+			PackerInfo{
+				builderName:  "tick-ami-ubuntu",
+				templatePath: "tick.json"},
+			0,
+		},
+		{
+			"TestTickSingleClusterAmazonLinux",
+			PackerInfo{
+				builderName:  "tick-ami-amazon-linux",
+				templatePath: "tick.json"},
+			3,
+		},
+	}
+
+	for _, testCase := range testcases {
+		// The following is necessary to make sure testCase's values don't
+		// get updated due to concurrency within the scope of t.Run(..) below
+		testCase := testCase
+
+		t.Run(testCase.testName, func(t *testing.T) {
+			t.Parallel()
+
+			// This is terrible - but attempt to stagger the test cases to
+			// avoid a concurrency issue
+			time.Sleep(time.Duration(testCase.sleepDuration) * time.Second)
+
+			examplesDir := test_structure.CopyTerraformFolderToTemp(t, "..", "/examples")
+			amiDir := fmt.Sprintf("%s/tick-ami", examplesDir)
+			templatePath := fmt.Sprintf("%s/%s", amiDir, testCase.packerInfo.templatePath)
+
+			defer test_structure.RunTestStage(t, "teardown", func() {
+				terraformOptions := test_structure.LoadTerraformOptions(t, examplesDir)
+				terraform.Destroy(t, terraformOptions)
+			})
+
+			test_structure.RunTestStage(t, "setup_ami", func() {
+				awsRegion := aws.GetRandomRegion(t, nil, []string{"eu-north-1"})
+				amiID := buildAmi(t, templatePath, testCase.packerInfo.builderName, awsRegion)
+
+				uniqueID := strings.ToLower(random.UniqueId())
+				clusterName := fmt.Sprintf("tick-%s", uniqueID)
+
+				keyPair := aws.CreateAndImportEC2KeyPair(t, awsRegion, uniqueID)
+				test_structure.SaveEc2KeyPair(t, examplesDir, keyPair)
+
+				licenseKey := os.Getenv("LICENSE_KEY")
+				sharedSecret := os.Getenv("SHARED_SECRET")
+
+				require.NotEmpty(t, licenseKey, "License key must be set as an env var and not included as plain-text")
+				require.NotEmpty(t, sharedSecret, "Shared secret must be set as an env var and not included as plain-text")
+
+				terraformOptions := &terraform.Options{
+					// The path to where your Terraform code is located
+					TerraformDir: fmt.Sprintf("%s/tick-single-cluster", examplesDir),
+					Vars: map[string]interface{}{
+						"aws_region":    awsRegion,
+						"ami_id":        amiID,
+						"ssh_key_name":  keyPair.Name,
+						"cluster_name":  clusterName,
+						"license_key":   licenseKey,
+						"shared_secret": sharedSecret,
+					},
+				}
+
+				test_structure.SaveTerraformOptions(t, examplesDir, terraformOptions)
+			})
+
+			test_structure.RunTestStage(t, "deploy_to_aws", func() {
+				terraformOptions := test_structure.LoadTerraformOptions(t, examplesDir)
+				terraform.InitAndApply(t, terraformOptions)
+			})
+
+			test_structure.RunTestStage(t, "validate_influxdb", func() {
+				terraformOptions := test_structure.LoadTerraformOptions(t, examplesDir)
+				endpoint := terraform.Output(t, terraformOptions, "lb_dns_name")
+				port := terraform.Output(t, terraformOptions, "influxdb_port")
+				validateInfluxdb(t, endpoint, port)
+			})
+
+			test_structure.RunTestStage(t, "validate_telegraf", func() {
+				terraformOptions := test_structure.LoadTerraformOptions(t, examplesDir)
+				endpoint := terraform.Output(t, terraformOptions, "lb_dns_name")
+				port := terraform.Output(t, terraformOptions, "influxdb_port")
+				validateTelegraf(t, endpoint, port, "telegraf")
+			})
+
+			test_structure.RunTestStage(t, "validate_chronograf", func() {
+				terraformOptions := test_structure.LoadTerraformOptions(t, examplesDir)
+				endpoint := terraform.Output(t, terraformOptions, "lb_dns_name")
+				port := terraform.Output(t, terraformOptions, "chronograf_port")
+				validateChronograf(t, endpoint, port)
+			})
+		})
+	}
+}


### PR DESCRIPTION
This PR adds an example for demonstrating how to deploy all TICK components* on a single AMI. It also adds accompanying automated tests.

(*) Kapacitor will be included at a later date