### PR TITLE
fix: incorrect utilization of condition

### DIFF
--- a/modules/load-balancer-target-group/main.tf
+++ b/modules/load-balancer-target-group/main.tf
@@ -38,7 +38,7 @@ resource "aws_alb_listener_rule" "http_path" {
     type             = "forward"
   }
 
-  condition = "${var.routing_condition}"
+  condition = ["${var.routing_condition}"]
 }
 
 # ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
condition needs to be a list of maps.  The var declaration is correct, but it's use is incorrect.  It needs the square brackets to preserve it as a list or else the terraform provider complains.