### PR TITLE
Enable nightly builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,3 +78,16 @@ workflows:
               only: /^v.*/
             branches:
               ignore: /.*/
+
+  nightly:
+    triggers:
+      - schedule:
+          cron: "0 6 * * *"
+          filters:
+            branches:
+              only: master
+    jobs:
+      - install_dependencies
+      - test:
+          requires:
+            - install_dependencies


### PR DESCRIPTION
This PR enables nightly builds on CircleCI as per the AWS Provider 2.0.0 milestone.