### PR TITLE
Chronograf ASG

### DIFF
--- a/modules/chronograf-server/main.tf
+++ b/modules/chronograf-server/main.tf
@@ -1,14 +1,69 @@
 # ---------------------------------------------------------------------------------------------------------------------
-# CREATE AN EC2 INSTANCE TO RUN CHRONOGRAF
+# CREATE A SINGLE NODE AUTO SCALING GROUP (ASG) TO RUN CHRONOGRAF
 # ---------------------------------------------------------------------------------------------------------------------
 
-resource "aws_instance" "chronograf_server" {
-  ami                    = "${var.ami_id}"
-  instance_type          = "${var.instance_type}"
-  user_data              = "${var.user_data}"
-  key_name               = "${var.ssh_key_name}"
-  vpc_security_group_ids = ["${aws_security_group.chronograf_security_group.id}"]
-  tags                   = "${merge(map("Name", "${var.server_name}"), var.tags)}"
+resource "aws_autoscaling_group" "autoscaling_group" {
+  name = "${var.cluster_name}"
+
+  launch_configuration = "${aws_launch_configuration.launch_configuration.name}"
+  vpc_zone_identifier  = ["${var.subnet_ids}"]
+
+  min_size             = "1"
+  max_size             = "1"
+  termination_policies = ["${var.termination_policies}"]
+
+  health_check_type         = "${var.health_check_type}"
+  health_check_grace_period = "${var.health_check_grace_period}"
+  wait_for_capacity_timeout = "${var.wait_for_capacity_timeout}"
+
+  tags = [
+    {
+      key                 = "Name"
+      value               = "${var.cluster_name}"
+      propagate_at_launch = true
+    },
+    "${var.tags}",
+  ]
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# CREATE LAUNCH CONFIGURATION TO DEFINE WHAT RUNS ON EACH INSTANCE IN THE ASG
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_launch_configuration" "launch_configuration" {
+  name_prefix   = "${var.cluster_name}-"
+  image_id      = "${var.ami_id}"
+  instance_type = "${var.instance_type}"
+  user_data     = "${var.user_data}"
+  spot_price    = "${var.spot_price}"
+
+  iam_instance_profile        = "${aws_iam_instance_profile.instance_profile.name}"
+  key_name                    = "${var.ssh_key_name}"
+  security_groups             = ["${aws_security_group.lc_security_group.id}"]
+  placement_tenancy           = "${var.tenancy}"
+  associate_public_ip_address = "${var.associate_public_ip_address}"
+
+  ebs_optimized = "${var.root_volume_ebs_optimized}"
+
+  root_block_device {
+    volume_type           = "${var.root_volume_type}"
+    volume_size           = "${var.root_volume_size}"
+    delete_on_termination = "${var.root_volume_delete_on_termination}"
+    iops                  = "${var.root_volume_iops}"
+  }
+
+  ebs_block_device = "${var.ebs_block_devices}"
+
+  # Important note: whenever using a launch configuration with an auto scaling group, you must set
+  # create_before_destroy = true. However, as soon as you set create_before_destroy = true in one resource, you must
+  # also set it in every resource that it depends on, or you'll get an error about cyclic dependencies (especially when
+  # removing resources). For more info, see:
+  #
+  # https://www.terraform.io/docs/providers/aws/r/launch_configuration.html
+  # https://terraform.io/docs/configuration/resources.html
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -16,8 +71,8 @@ resource "aws_instance" "chronograf_server" {
 # We export the ID of the security group as an output variable so users can attach custom rules.
 # ---------------------------------------------------------------------------------------------------------------------
 
-resource "aws_security_group" "chronograf_security_group" {
-  name_prefix = "${var.server_name}-"
+resource "aws_security_group" "lc_security_group" {
+  name_prefix = "${var.cluster_name}-"
   description = "Security group for the Chronograf server"
   vpc_id      = "${var.vpc_id}"
 }
@@ -34,7 +89,7 @@ resource "aws_security_group_rule" "allow_ssh_inbound" {
   protocol    = "tcp"
   cidr_blocks = ["${var.allowed_ssh_cidr_blocks}"]
 
-  security_group_id = "${aws_security_group.chronograf_security_group.id}"
+  security_group_id = "${aws_security_group.lc_security_group.id}"
 }
 
 resource "aws_security_group_rule" "allow_ssh_inbound_from_security_group_ids" {
@@ -45,7 +100,7 @@ resource "aws_security_group_rule" "allow_ssh_inbound_from_security_group_ids" {
   protocol                 = "tcp"
   source_security_group_id = "${element(var.allowed_ssh_security_group_ids, count.index)}"
 
-  security_group_id = "${aws_security_group.chronograf_security_group.id}"
+  security_group_id = "${aws_security_group.lc_security_group.id}"
 }
 
 resource "aws_security_group_rule" "allow_all_outbound" {
@@ -55,5 +110,49 @@ resource "aws_security_group_rule" "allow_all_outbound" {
   protocol    = "-1"
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.chronograf_security_group.id}"
+  security_group_id = "${aws_security_group.lc_security_group.id}"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# ATTACH AN IAM ROLE TO EACH EC2 INSTANCE
+# We can use the IAM role to grant the instance IAM permissions so we can use the AWS CLI without having to figure out
+# how to get our secret AWS access keys onto the box. We export the ID of the IAM role as an output variable so users
+# can attach custom policies.
+# ---------------------------------------------------------------------------------------------------------------------
+
+resource "aws_iam_instance_profile" "instance_profile" {
+  name_prefix = "${var.cluster_name}"
+  path        = "${var.instance_profile_path}"
+  role        = "${aws_iam_role.instance_role.name}"
+
+  # aws_launch_configuration.launch_configuration in this module sets create_before_destroy to true, which means
+  # everything it depends on, including this resource, must set it as well, or you'll get cyclic dependency errors
+  # when you try to do a terraform destroy.
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_iam_role" "instance_role" {
+  name_prefix        = "${var.cluster_name}"
+  assume_role_policy = "${data.aws_iam_policy_document.instance_role.json}"
+
+  # aws_iam_instance_profile.instance_profile in this module sets create_before_destroy to true, which means
+  # everything it depends on, including this resource, must set it as well, or you'll get cyclic dependency errors
+  # when you try to do a terraform destroy.
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+data "aws_iam_policy_document" "instance_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
 }

--- a/modules/chronograf-server/main.tf
+++ b/modules/chronograf-server/main.tf
@@ -8,8 +8,8 @@ resource "aws_autoscaling_group" "autoscaling_group" {
   launch_configuration = "${aws_launch_configuration.launch_configuration.name}"
   vpc_zone_identifier  = ["${var.subnet_ids}"]
 
-  min_size             = "1"
-  max_size             = "1"
+  min_size             = 1
+  max_size             = 1
   termination_policies = ["${var.termination_policies}"]
 
   health_check_type         = "${var.health_check_type}"

--- a/modules/chronograf-server/outputs.tf
+++ b/modules/chronograf-server/outputs.tf
@@ -1,7 +1,23 @@
-output "public_ip" {
-  value = "${aws_instance.chronograf_server.public_ip}"
+output "asg_name" {
+  value = "${aws_autoscaling_group.autoscaling_group.name}"
+}
+
+output "cluster_size" {
+  value = "${aws_autoscaling_group.autoscaling_group.desired_capacity}"
+}
+
+output "launch_configuration_name" {
+  value = "${aws_launch_configuration.launch_configuration.name}"
+}
+
+output "iam_role_arn" {
+  value = "${aws_iam_role.instance_role.arn}"
+}
+
+output "iam_role_id" {
+  value = "${aws_iam_role.instance_role.id}"
 }
 
 output "security_group_id" {
-  value = "${aws_security_group.chronograf_security_group.id}"
+  value = "${aws_security_group.lc_security_group.id}"
 }

--- a/modules/chronograf-server/variables.tf
+++ b/modules/chronograf-server/variables.tf
@@ -61,7 +61,7 @@ variable "termination_policies" {
 }
 
 variable "associate_public_ip_address" {
-  description = "If set to true, associate a public IP address with each EC2 Instance in the cluster."
+  description = "If set to true, associate a public IP address with each EC2 Instance in the auto scaling group."
   default     = false
 }
 

--- a/modules/chronograf-server/variables.tf
+++ b/modules/chronograf-server/variables.tf
@@ -56,7 +56,7 @@ variable "allowed_ssh_security_group_ids_num" {
 }
 
 variable "termination_policies" {
-  description = "A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are OldestInstance, NewestInstance, OldestLaunchConfiguration, ClosestToNextInstanceHour, Default."
+  description = "A list of policies to decide how the instances in the auto scaling group should be terminated. The allowed values are OldestInstance, NewestInstance, OldestLaunchConfiguration, ClosestToNextInstanceHour, Default."
   default     = "Default"
 }
 

--- a/modules/chronograf-server/variables.tf
+++ b/modules/chronograf-server/variables.tf
@@ -3,7 +3,7 @@
 # You must provide a value for each of these parameters.
 # ---------------------------------------------------------------------------------------------------------------------
 
-variable "server_name" {
+variable "cluster_name" {
   description = "The name of the Chronograf server. This variable is used to namespace all resources created by this module."
 }
 
@@ -17,6 +17,11 @@ variable "instance_type" {
 
 variable "vpc_id" {
   description = "The ID of the VPC in which to deploy the InfluxDB cluster"
+}
+
+variable "subnet_ids" {
+  description = "The subnet IDs into which the EC2 Instances should be deployed."
+  type        = "list"
 }
 
 variable "user_data" {
@@ -50,13 +55,106 @@ variable "allowed_ssh_security_group_ids_num" {
   default     = 0
 }
 
+variable "termination_policies" {
+  description = "A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are OldestInstance, NewestInstance, OldestLaunchConfiguration, ClosestToNextInstanceHour, Default."
+  default     = "Default"
+}
+
+variable "associate_public_ip_address" {
+  description = "If set to true, associate a public IP address with each EC2 Instance in the cluster."
+  default     = false
+}
+
+variable "spot_price" {
+  description = "The maximum hourly price to pay for EC2 Spot Instances."
+  default     = ""
+}
+
+variable "tenancy" {
+  description = "The tenancy of the instance. Must be one of: empty string, default, or dedicated. For EC2 Spot Instances only empty string or dedicated can be used."
+  default     = ""
+}
+
+variable "root_volume_ebs_optimized" {
+  description = "If true, the launched EC2 instance will be EBS-optimized."
+  default     = false
+}
+
+variable "root_volume_type" {
+  description = "The type of volume. Must be one of: standard, gp2, or io1."
+  default     = "gp2"
+}
+
+variable "root_volume_size" {
+  description = "The size, in GB, of the root EBS volume."
+  default     = 50
+}
+
+variable "root_volume_delete_on_termination" {
+  description = "Whether the volume should be destroyed on instance termination."
+  default     = true
+}
+
+variable "root_volume_iops" {
+  description = "The amount of provisioned IOPS for the root volume. Only used if volume type is io1."
+  default     = 0
+}
+
+variable "ebs_block_devices" {
+  description = "A list of EBS volumes to attach to each EC2 Instance. Each item in the list should be an object with the keys 'device_name', 'volume_type', 'volume_size', 'iops', 'delete_on_termination', and 'encrypted', as defined here: https://www.terraform.io/docs/providers/aws/r/launch_configuration.html#block-devices. We recommend using one EBS Volume for each instance."
+  type        = "list"
+  default     = []
+
+  # Example:
+  #
+  # default = [
+  #   {
+  #     device_name = "/dev/xvdh"
+  #     volume_type = "gp2"
+  #     volume_size = 300
+  #     encrypted   = true
+  #   }
+  # ]
+}
+
+variable "wait_for_capacity_timeout" {
+  description = "A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to '0' causes Terraform to skip all Capacity Waiting behavior."
+  default     = "10m"
+}
+
+variable "health_check_type" {
+  description = "Controls how health checking is done. Must be one of EC2 or ELB."
+  default     = "EC2"
+}
+
+variable "health_check_grace_period" {
+  description = "Time, in seconds, after instance comes into service before checking health."
+  default     = 600
+}
+
+variable "instance_profile_path" {
+  description = "Path in which to create the IAM instance profile."
+  default     = "/"
+}
+
 variable "ssh_port" {
   description = "The port used for SSH connections"
   default     = 22
 }
 
 variable "tags" {
-  description = "Tags to attach to the EC2 Instance."
-  type        = "map"
-  default     = {}
+  description = "List fo extra tag blocks added to the autoscaling group configuration. Each element in the list is a map containing keys 'key', 'value', and 'propagate_at_launch' mapped to the respective values."
+  type        = "list"
+  default     = []
+
+  # Example:
+  #
+  # default = [
+  #   {
+  #     key                 = "foo"
+  #     value               = "bar"
+  #     propagate_at_launch = true
+  #   }
+  # ]
 }
+

--- a/modules/chronograf-server/variables.tf
+++ b/modules/chronograf-server/variables.tf
@@ -143,7 +143,7 @@ variable "ssh_port" {
 }
 
 variable "tags" {
-  description = "List fo extra tag blocks added to the autoscaling group configuration. Each element in the list is a map containing keys 'key', 'value', and 'propagate_at_launch' mapped to the respective values."
+  description = "List of extra tag blocks added to the auto scaling group configuration. Each element in the list is a map containing keys 'key', 'value', and 'propagate_at_launch' mapped to the respective values."
   type        = "list"
   default     = []
 

--- a/modules/kapacitor-server/main.tf
+++ b/modules/kapacitor-server/main.tf
@@ -8,8 +8,8 @@ resource "aws_autoscaling_group" "autoscaling_group" {
   launch_configuration = "${aws_launch_configuration.launch_configuration.name}"
   vpc_zone_identifier  = ["${var.subnet_ids}"]
 
-  min_size             = "1"
-  max_size             = "1"
+  min_size             = 1
+  max_size             = 1
   termination_policies = ["${var.termination_policies}"]
 
   health_check_type         = "${var.health_check_type}"


### PR DESCRIPTION
This PR updates Chronograf's Terraform module to use a single node autoscaling group instead of a single EC2 instance. This will allow automatic spinning up of the server if it goes down for any reason.