### PR TITLE
Update all repo names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,14 @@
 defaults: &defaults
   machine: true
-  environment:
-    GRUNTWORK_INSTALLER_VERSION: v0.0.30
-    TERRATEST_LOG_PARSER_VERSION: v0.30.10
-    MODULE_CI_VERSION: v0.29.0
-    TERRAFORM_VERSION: 0.13.4
-    TERRAGRUNT_VERSION: NONE
-    PACKER_VERSION: 1.6.1
-    GOLANG_VERSION: 1.14
+
+env: &env
+  GRUNTWORK_INSTALLER_VERSION: v0.0.30
+  TERRATEST_LOG_PARSER_VERSION: v0.30.10
+  MODULE_CI_VERSION: v0.29.0
+  TERRAFORM_VERSION: 0.13.4
+  TERRAGRUNT_VERSION: NONE
+  PACKER_VERSION: 1.6.1
+  GOLANG_VERSION: 1.14
 
 install_gruntwork_utils: &install_gruntwork_utils
   name: install gruntwork utils
@@ -23,8 +24,10 @@ install_gruntwork_utils: &install_gruntwork_utils
 
 version: 2
 jobs:
-  build:
-    <<: *defaults
+  precommit:
+    <<: *env
+    docker:
+      - image: circleci/python:3.8.1
     steps:
       - checkout
       # Install gruntwork utilities
@@ -33,22 +36,15 @@ jobs:
 
       # Fail the build if the pre-commit hooks don't pass. Note: if you run pre-commit install locally, these hooks will
       # execute automatically every time before you commit, ensuring the build never fails at this step!
-      - run: pip install pre-commit==1.11.2 cfgv==2.0.1 yapf
-      - run: pre-commit install
-      - run: pre-commit run --all-files
-
-      - persist_to_workspace:
-          root: /home/circleci
-          paths:
-            - project
-            - terraform
-            - packer
+      - run:
+          command: |
+            pip install pre-commit==1.21.0 cfgv==2.0.1 zipp==1.1.0 yapf
+            pre-commit install
+            pre-commit run --all-files
 
   test:
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: /home/circleci
       - checkout
       - run: echo 'export PATH=$HOME/terraform:$HOME/packer:$PATH' >> $BASH_ENV
       - run:
@@ -88,12 +84,12 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      - build:
+      - precommit:
           context:
             - Gruntwork Admin
       - test:
           requires:
-            - build
+            - precommit
           context:
             - Gruntwork Admin
       - release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,14 @@ defaults: &defaults
   machine: true
 
 env: &env
-  GRUNTWORK_INSTALLER_VERSION: v0.0.30
-  TERRATEST_LOG_PARSER_VERSION: v0.30.10
-  MODULE_CI_VERSION: v0.29.0
-  TERRAFORM_VERSION: 0.13.4
-  TERRAGRUNT_VERSION: NONE
-  PACKER_VERSION: 1.6.1
-  GOLANG_VERSION: 1.14
+  environment:
+    GRUNTWORK_INSTALLER_VERSION: v0.0.30
+    TERRATEST_LOG_PARSER_VERSION: v0.30.10
+    MODULE_CI_VERSION: v0.29.0
+    TERRAFORM_VERSION: 0.13.4
+    TERRAGRUNT_VERSION: NONE
+    PACKER_VERSION: 1.6.1
+    GOLANG_VERSION: 1.14
 
 install_gruntwork_utils: &install_gruntwork_utils
   name: install gruntwork utils

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ install_gruntwork_utils: &install_gruntwork_utils
   name: install gruntwork utils
   command: |
     curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version "${GRUNTWORK_INSTALLER_VERSION}"
-    gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "${MODULE_CI_VERSION}"
+    gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/terraform-aws-ci" --tag "${MODULE_CI_VERSION}"
     gruntwork-install --binary-name "terratest_log_parser" --repo "https://github.com/gruntwork-io/terratest" --tag "${TERRATEST_LOG_PARSER_VERSION}"
     configure-environment-for-gruntwork-module \
       --terraform-version ${TERRAFORM_VERSION} \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ jobs:
 
   test:
     <<: *defaults
+    <<: *env
     steps:
       - checkout
       - run: echo 'export PATH=$HOME/terraform:$HOME/packer:$PATH' >> $BASH_ENV
@@ -68,6 +69,7 @@ jobs:
 
   release:
     <<: *defaults
+    <<: *env
     steps:
       - checkout
 

--- a/examples/tick-single-cluster/README.md
+++ b/examples/tick-single-cluster/README.md
@@ -19,7 +19,7 @@ example](https://github.com/gruntwork-io/terraform-aws-influx/blob/master/exampl
 1. A single _all in one server_ behind an ASG where we run 
     [telegraf](/modules/run-telegraf), [influxdb](/modules/run-influxdb),
     [chronograf](/modules/run-chronograf) and [kapacitor](/modules/run-kapacitor)
-1. An [Application Load Balancer](https://github.com/gruntwork-io/module-load-balancer)
+1. An [Application Load Balancer](https://github.com/gruntwork-io/terraform-aws-load-balancer)
 
 You will need to create [Amazon Machine Images (AMIs)](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) 
 that have all of the TICK-stack components installed. You can do this using: 


### PR DESCRIPTION
_**This PR was created by git-xargs. See https://github.com/gruntwork-io/prototypes/pull/152 for context.**_ We recently renamed all of our repos to follow the Terraform registry format of  (e.g., ). This PR does a search & replace to update all references to these repos to the new names. GitHub can handle redirects, so in theory, everything should work fine with the old names, but there were so many renames, that to reduce confusion, this will update most of our references to the proper values.